### PR TITLE
Reusefix must take topic resource types into account. Both cloning, a…

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/TopicReusedInSameSubjectCloningService.java
+++ b/src/main/java/no/ndla/taxonomy/service/TopicReusedInSameSubjectCloningService.java
@@ -161,11 +161,11 @@ public class TopicReusedInSameSubjectCloningService {
         private int topicCloningSerial = 0;
 
         public class TopicCloning {
-            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic"})
+            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic", "topicResourceTypes"})
             private Topic parentTopic;
-            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic"})
+            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic", "topicResourceTypes"})
             private Topic topic;
-            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic"})
+            @JsonIgnoreProperties({"subjects", "subtopics", "parentTopics", "resources", "filters", "translations", "primaryParentTopic", "topicResourceTypes"})
             private Topic clonedTopic;
             private List<TopicCloning> clonedSubtopics;
 
@@ -241,6 +241,8 @@ public class TopicReusedInSameSubjectCloningService {
                 }
                 /* translations */
                 topic.getTranslations().forEachRemaining(translation -> clonedTopic.addTranslation(translation.getLanguageCode()).setName(translation.getName()));
+                /* resource types */
+                topic.topicResourceTypes.forEach(topicResourceType -> clonedTopic.addResourceType(topicResourceType.getResourceType()));
 
                 clonedTopic = topicRepository.save(clonedTopic);
 


### PR DESCRIPTION
…nd ignoring in json serialization to avoid a serialization loop. The objects are not readuy for jackson serialization with full structure.