### PR TITLE
Return contentUri for filters in subject

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/subjects/FilterIndexDocument.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/subjects/FilterIndexDocument.java
@@ -7,6 +7,7 @@ import no.ndla.taxonomy.domain.Filter;
 
 import java.net.URI;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  *
@@ -21,13 +22,18 @@ public class FilterIndexDocument {
     @ApiModelProperty(value = "Filter name", example = "1T-YF")
     public String name;
 
+    @JsonProperty
+    @ApiModelProperty(value = "ID of frontpage introducing this filter.", example = "urn:frontpage:1")
+    public Optional<URI> contentUri;
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         FilterIndexDocument that = (FilterIndexDocument) o;
         return Objects.equals(id, that.id) &&
-                Objects.equals(name, that.name);
+                Objects.equals(name, that.name) &&
+                Objects.equals(contentUri, that.contentUri);
     }
 
     @Override
@@ -41,5 +47,6 @@ public class FilterIndexDocument {
     public FilterIndexDocument(Filter filter) {
         this.id = filter.getPublicId();
         this.name = filter.getName();
+        this.contentUri = filter.getContentUri();
     }
 }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/SubjectFiltersTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/SubjectFiltersTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.net.URI;
+import java.util.Optional;
 
 import static no.ndla.taxonomy.TestUtils.assertAnyTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,7 +40,7 @@ public class SubjectFiltersTest extends RestTest {
         builder.subject(s -> s
                 .name("Byggfag")
                 .publicId("urn:subject:1")
-                .filter(f -> f.name("Tømrer"))
+                .filter(f -> f.name("Tømrer").contentUri(URI.create("urn:frontpage:1")))
                 .filter(f -> f.name("Rørlegger"))
         );
 
@@ -49,6 +50,7 @@ public class SubjectFiltersTest extends RestTest {
         assertEquals(2, filters.length);
         assertAnyTrue(filters, f -> f.name.equals("Tømrer"));
         assertAnyTrue(filters, f -> f.name.equals("Rørlegger"));
+        assertAnyTrue(filters, f -> f.contentUri.equals(Optional.of(URI.create("urn:frontpage:1"))));
     }
 
     @Test


### PR DESCRIPTION
Fant ut at eg trenger å få contenturi når eg henter filter for et fag.