### PR TITLE
Thread safe maps to cache metadata injection based on Class. Concurre…

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/MetadataInjectAspect.java
+++ b/src/main/java/no/ndla/taxonomy/service/MetadataInjectAspect.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Aspect
@@ -19,10 +20,10 @@ import java.util.stream.Collectors;
 public class MetadataInjectAspect {
     private final MetadataApiService metadataApiService;
 
-    private final Map<Class<?>, Optional<Method>> setMetadataMethods = new HashMap<>();
-    private final Map<Class<?>, Set<Field>> allFields = new HashMap<>();
-    private final Map<Class<?>, Set<Field>> metadataInjectFields = new HashMap<>();
-    private final Map<Class<?>, Set<Field>> metadataIdFields = new HashMap<>();
+    private final Map<Class<?>, Optional<Method>> setMetadataMethods = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Set<Field>> allFields = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Set<Field>> metadataInjectFields = new ConcurrentHashMap<>();
+    private final Map<Class<?>, Set<Field>> metadataIdFields = new ConcurrentHashMap<>();
 
     private final Logger log = LoggerFactory.getLogger(MetadataInjectAspect.class);
 


### PR DESCRIPTION
…ntHashMap should not negatively impact read performance, but at the same time synchronize writes. With the previous version there is a probability of ConcurrentModificationException's and issues the first code path hits after (re)start of service. Could cause 500's, but will stop doing that over time, so this is not a huge issue.