### PR TITLE
Disabling old cached paths on update. Delete disabled paths afterwards.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/SchedulingConfig.java
+++ b/src/main/java/no/ndla/taxonomy/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package no.ndla.taxonomy.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/no/ndla/taxonomy/domain/CachedPath.java
+++ b/src/main/java/no/ndla/taxonomy/domain/CachedPath.java
@@ -13,6 +13,9 @@ public class CachedPath {
     @Column(name = "is_primary")
     private boolean primary;
 
+    @Column(name = "is_active")
+    private boolean active = true;
+
     @Column
     @Id
     private UUID id;
@@ -65,6 +68,18 @@ public class CachedPath {
 
     public void setPrimary(boolean primary) {
         this.primary = primary;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
+
+    public void disable() {
+        setActive(false);
     }
 
     public Optional<EntityWithPath> getOwningEntity() {

--- a/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
+++ b/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
@@ -18,6 +18,7 @@ public abstract class EntityWithPath extends DomainObject {
         }
     }
 
+    @Deprecated
     public void removeCachedPath(CachedPath cachedPath) {
         this.getCachedPaths().remove(cachedPath);
 
@@ -29,6 +30,7 @@ public abstract class EntityWithPath extends DomainObject {
     public Optional<String> getPrimaryPath() {
         return getCachedPaths()
                 .stream()
+                .filter(CachedPath::isActive)
                 .filter(CachedPath::isPrimary)
                 .map(CachedPath::getPath)
                 .findFirst();
@@ -89,7 +91,7 @@ public abstract class EntityWithPath extends DomainObject {
     }
 
     public Set<String> getAllPaths() {
-        return getCachedPaths().stream().map(CachedPath::getPath).collect(Collectors.toSet());
+        return getCachedPaths().stream().filter(CachedPath::isActive).map(CachedPath::getPath).collect(Collectors.toSet());
     }
 
     abstract public URI getContentUri();

--- a/src/main/java/no/ndla/taxonomy/repositories/CachedPathRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/CachedPathRepository.java
@@ -2,10 +2,14 @@ package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.CachedPath;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 
+import javax.persistence.LockModeType;
 import java.net.URI;
 import java.util.List;
 
 public interface CachedPathRepository extends JpaRepository<CachedPath, String> {
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     List<CachedPath> findAllByPublicId(URI publicId);
 }

--- a/src/main/java/no/ndla/taxonomy/repositories/CachedPathRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/CachedPathRepository.java
@@ -2,14 +2,15 @@ package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.CachedPath;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
-import javax.persistence.LockModeType;
 import java.net.URI;
 import java.util.List;
 
 public interface CachedPathRepository extends JpaRepository<CachedPath, String> {
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select cp from CachedPath cp where cp.active = true and cp.publicId = ?1")
     List<CachedPath> findAllByPublicId(URI publicId);
+
+    int deleteByActiveFalse();
 }

--- a/src/main/java/no/ndla/taxonomy/service/CachedPathCleaner.java
+++ b/src/main/java/no/ndla/taxonomy/service/CachedPathCleaner.java
@@ -1,0 +1,22 @@
+package no.ndla.taxonomy.service;
+
+import no.ndla.taxonomy.repositories.CachedPathRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class CachedPathCleaner {
+    private final CachedPathRepository cachedPathRepository;
+
+    public CachedPathCleaner(CachedPathRepository cachedPathRepository) {
+        this.cachedPathRepository = cachedPathRepository;
+    }
+
+    @Scheduled(fixedRate = 10000)
+    @Transactional
+    public void removeInactivePaths() {
+        cachedPathRepository.deleteByActiveFalse();
+    }
+}

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -770,4 +770,15 @@
         <dropForeignKeyConstraint baseTableName="topic_filter" constraintName="topic_filter_relevance_id_fkey"/>
         <dropForeignKeyConstraint baseTableName="filter" constraintName="filter_subject_id_fkey"/>
     </changeSet>
+
+    <changeSet id="20210623" author="Gunnar Velle">
+        <!-- Adds active flag used to cached_path to avoid database locks -->
+        <addColumn tableName="cached_path">
+            <column name="is_active" type="boolean" defaultValue="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <!-- remove constraint for unique path in cached_path -->
+        <dropUniqueConstraint tableName="cached_path" constraintName="unique_cached_path_path"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -778,7 +778,11 @@
                 <constraints nullable="false"/>
             </column>
         </addColumn>
+    </changeSet>
+
+    <changeSet id="20210623_2" author="Gunnar Velle">
         <!-- remove constraint for unique path in cached_path -->
         <dropUniqueConstraint tableName="cached_path" constraintName="unique_cached_path_path"/>
     </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -772,7 +772,7 @@
     </changeSet>
 
     <changeSet id="20210623" author="Gunnar Velle">
-        <!-- Adds active flag used to cached_path to avoid database locks -->
+        <!-- Adds active flag to cached_path to avoid database locks -->
         <addColumn tableName="cached_path">
             <column name="is_active" type="boolean" defaultValue="true">
                 <constraints nullable="false"/>

--- a/src/test/java/no/ndla/taxonomy/domain/EntityWithPathTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/EntityWithPathTest.java
@@ -38,6 +38,9 @@ public class EntityWithPathTest {
         when(cachedUrl1.getPath()).thenReturn("/path1");
         when(cachedUrl2.getPath()).thenReturn("/path2");
         when(cachedUrl3.getPath()).thenReturn("/path3");
+        when(cachedUrl1.isActive()).thenReturn(true);
+        when(cachedUrl2.isActive()).thenReturn(true);
+        when(cachedUrl3.isActive()).thenReturn(true);
         when(cachedUrl1.isPrimary()).thenReturn(false);
         when(cachedUrl2.isPrimary()).thenReturn(false);
         when(cachedUrl3.isPrimary()).thenReturn(true);
@@ -95,15 +98,22 @@ public class EntityWithPathTest {
         final var cachedUrl1 = mock(CachedPath.class);
         final var cachedUrl2 = mock(CachedPath.class);
         final var cachedUrl3 = mock(CachedPath.class);
+        final var cachedUrl4 = mock(CachedPath.class);
 
         when(cachedUrl1.getPath()).thenReturn("/path1");
         when(cachedUrl2.getPath()).thenReturn("/path2");
         when(cachedUrl3.getPath()).thenReturn("/path3");
+        when(cachedUrl4.getPath()).thenReturn("/path4");
         when(cachedUrl1.isPrimary()).thenReturn(false);
         when(cachedUrl2.isPrimary()).thenReturn(false);
         when(cachedUrl3.isPrimary()).thenReturn(true);
+        when(cachedUrl4.isPrimary()).thenReturn(true);
+        when(cachedUrl1.isActive()).thenReturn(true);
+        when(cachedUrl2.isActive()).thenReturn(true);
+        when(cachedUrl3.isActive()).thenReturn(true);
+        when(cachedUrl4.isActive()).thenReturn(false);
 
-        when(entityWithPath.getCachedPaths()).thenReturn(Set.of(cachedUrl1, cachedUrl2, cachedUrl3));
+        when(entityWithPath.getCachedPaths()).thenReturn(Set.of(cachedUrl1, cachedUrl2, cachedUrl3, cachedUrl4));
 
         final var allPaths = entityWithPath.getAllPaths();
 

--- a/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.net.URI;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ class CachedUrlUpdaterServiceImplTest {
     private CachedPathRepository cachedPathRepository;
     private CachedUrlUpdaterServiceImpl service;
 
+    private EntityManager entityManager;
     private SubjectRepository subjectRepository;
     private TopicRepository topicRepository;
     private ResourceRepository resourceRepository;
@@ -33,13 +35,15 @@ class CachedUrlUpdaterServiceImplTest {
     void setup(@Autowired CachedPathRepository cachedPathRepository,
                @Autowired SubjectRepository subjectRepository,
                @Autowired TopicRepository topicRepository,
-               @Autowired ResourceRepository resourceRepository) {
+               @Autowired ResourceRepository resourceRepository,
+               @Autowired EntityManager entityManager) {
         this.cachedPathRepository = cachedPathRepository;
         this.subjectRepository = subjectRepository;
         this.topicRepository = topicRepository;
         this.resourceRepository = resourceRepository;
+        this.entityManager = entityManager;
 
-        service = new CachedUrlUpdaterServiceImpl(cachedPathRepository);
+        service = new CachedUrlUpdaterServiceImpl(cachedPathRepository, entityManager);
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityManager;
 import java.net.URI;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImplTest.java
@@ -26,7 +26,6 @@ class CachedUrlUpdaterServiceImplTest {
     private CachedPathRepository cachedPathRepository;
     private CachedUrlUpdaterServiceImpl service;
 
-    private EntityManager entityManager;
     private SubjectRepository subjectRepository;
     private TopicRepository topicRepository;
     private ResourceRepository resourceRepository;
@@ -35,15 +34,13 @@ class CachedUrlUpdaterServiceImplTest {
     void setup(@Autowired CachedPathRepository cachedPathRepository,
                @Autowired SubjectRepository subjectRepository,
                @Autowired TopicRepository topicRepository,
-               @Autowired ResourceRepository resourceRepository,
-               @Autowired EntityManager entityManager) {
+               @Autowired ResourceRepository resourceRepository) {
         this.cachedPathRepository = cachedPathRepository;
         this.subjectRepository = subjectRepository;
         this.topicRepository = topicRepository;
         this.resourceRepository = resourceRepository;
-        this.entityManager = entityManager;
 
-        service = new CachedUrlUpdaterServiceImpl(cachedPathRepository, entityManager);
+        service = new CachedUrlUpdaterServiceImpl(cachedPathRepository);
     }
 
     @Test
@@ -179,6 +176,7 @@ class CachedUrlUpdaterServiceImplTest {
 
         service.clearCachedUrls(subject1);
 
-        assertEquals(0, subject1.getCachedPaths().size());
+        assertEquals(1, subject1.getCachedPaths().size());
+        assertEquals(0, subject1.getCachedPaths().stream().filter(CachedPath::isActive).collect(Collectors.toSet()).size());
     }
 }


### PR DESCRIPTION
To samtidige oppdateringer av topic-resources vil begge forsøke å oppdatere cache-tabellen CachedPath. Då vil den eine trigge en exception fordi den ikkje klarer å låse radene den vil oppdatere.

~Koden setter en lokal transasjonstimeout på fem sekund slik at transaksjon nummer to venter på at første skal bli ferdig. Lokalt med èn instans av taksonomi funker det som regel med to samtidige transaksjoner, mens det feiler som oftest med tre.~

Setter et flagg på path som forteller at den er ugyldig. Sletter disse i etterkant.

