### PR TITLE
#2703: Adds path and paths fields to subtopics

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/dtos/SubTopicIndexDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/SubTopicIndexDTO.java
@@ -11,6 +11,7 @@ import no.ndla.taxonomy.service.MetadataIdField;
 import no.ndla.taxonomy.service.TopicTreeSorter;
 
 import java.net.URI;
+import java.util.Set;
 
 /**
  *
@@ -42,6 +43,14 @@ public class SubTopicIndexDTO implements TopicTreeSorter.Sortable {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private MetadataDto metadata;
 
+    @JsonProperty
+    @ApiModelProperty(value = "List of all paths to this subtopic")
+    private Set<String> paths;
+
+    @JsonProperty
+    @ApiModelProperty(value = "The primary path for this subtopic", example = "/subject:1/topic:1")
+    private String path;
+
     private int rank;
     private URI parentId;
 
@@ -58,11 +67,14 @@ public class SubTopicIndexDTO implements TopicTreeSorter.Sortable {
                     .orElse(topic.getName());
 
             this.contentUri = topic.getContentUri();
+            this.paths = topic.getAllPaths();
+            this.path = topic.getPrimaryPath().orElse(null);
         });
 
         this.isPrimary = true;
 
         this.rank = topicSubtopic.getRank();
+
         topicSubtopic.getTopic().ifPresent(topic -> this.parentId = topic.getPublicId());
 
         {


### PR DESCRIPTION
Fixes NDLANO/Issues#2703

Kan testes ved å sjekke at subtopic'ene på `/v1/topics/<topidId>/topics` får `path` og `paths` (som stemmer :smile:)
Må innrømme at jeg ikke har megakjennskap til hvordan det her henger sammen, så alle innspill tas i mot med takk :upside_down_face: 