### PR TITLE
#2743: Move metadata to abstract crud class

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -53,7 +53,7 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
         return "/v1/resources";
     }
 
-    @GetMapping("")
+    @GetMapping
     @ApiOperation(value = "Lists all resources")
     @Transactional(readOnly = true)
     public List<ResourceDTO> index(

--- a/src/test/java/no/ndla/taxonomy/rest/v1/MetadataControllerTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/MetadataControllerTest.java
@@ -1,7 +1,11 @@
 package no.ndla.taxonomy.rest.v1;
 
+import no.ndla.taxonomy.repositories.ResourceRepository;
+import no.ndla.taxonomy.repositories.ResourceResourceTypeRepository;
+import no.ndla.taxonomy.service.CachedUrlUpdaterService;
 import no.ndla.taxonomy.service.MetadataApiService;
 import no.ndla.taxonomy.service.MetadataUpdateService;
+import no.ndla.taxonomy.service.ResourceService;
 import no.ndla.taxonomy.service.dtos.MetadataDto;
 import no.ndla.taxonomy.service.dtos.RecursiveMergeResultDto;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,15 +23,32 @@ class MetadataControllerTest {
 
     private MetadataApiService metadataApiService;
     private MetadataUpdateService metadataUpdateService;
-    private MetadataController controller;
+    private ResourceRepository resourceRepository;
+    private ResourceResourceTypeRepository resourceResourceTypeRepository;
+    private ResourceService resourceService;
+    private CachedUrlUpdaterService cachedUrlUpdaterService;
+    private Resources controller;
 
     @BeforeEach
     public void setUp() {
         metadataApiService = mock(MetadataApiService.class);
         metadataUpdateService = mock(MetadataUpdateService.class);
+        resourceRepository = mock(ResourceRepository.class);
+        resourceResourceTypeRepository = mock(ResourceResourceTypeRepository.class);
+        resourceService = mock(ResourceService.class);
+        cachedUrlUpdaterService = mock(CachedUrlUpdaterService.class);
+
+
         when(metadataUpdateService.getMetadataApiService()).thenReturn(metadataApiService);
 
-        controller = new MetadataController(metadataApiService, metadataUpdateService);
+        controller = new Resources(
+                resourceRepository,
+                resourceResourceTypeRepository,
+                resourceService,
+                cachedUrlUpdaterService,
+                metadataApiService,
+                metadataUpdateService
+        );
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/TopicsWebTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/TopicsWebTest.java
@@ -53,6 +53,8 @@ public class TopicsWebTest {
     RecursiveTopicTreeService recursiveTopicTreeService;
     @MockBean
     MetadataUpdateService metadataUpdateService;
+    @MockBean
+    ResourceService resourceService;
 
     @Autowired
     private MockMvc mockMvc;


### PR DESCRIPTION
Fixes NDLANO/Issues#2743

Fant ut at vi _kan_ løse det på denne måten, og jeg tror jeg syns den er ryddigere enn å duplisere ting.
Flyttet endepunkter som hadde andre start paths enn `/v1/resources` til andre controllere for å få det til å fungere.

NB: Denne fjerner `/metadata` endepunktet på filter, men jeg gikk igjennom de andre repoene og klarte ikke finne et eneste sted det var brukt, så mistenker at det er greit.
Dersom vi vil ha på plass filter metadata endepunktene er det selvsagt mulig, men jeg valgte å ikke gjøre det siden alle filter endepunktene er deprekert alikevel og da måtte vi flyttet to av endepunktene ut i `Resources` og `Subjects`.


Kan testes ved å sjekke at `/v1/{ resources / topics / subjects }/{id}/metadata` endepunkene fungerer som tidligere og at swagger doc'en ser ryddigere ut.