### PR TITLE
#2706: Adds metadata key,val filtering to `/v1/resources` and `/v1/subjects` endpoints

### DIFF
--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
@@ -42,6 +42,18 @@ public interface ResourceRepository extends TaxonomyRepository<Resource> {
     )
     List<Resource> findByIdIncludingCachedUrlsAndResourceTypesAndFiltersAndTranslations(Collection<Integer> idSet);
 
+    @Query(
+            "SELECT distinct r" +
+                    "   FROM Resource r" +
+                    "   LEFT JOIN FETCH r.cachedPaths" +
+                    "   LEFT JOIN FETCH r.resourceResourceTypes rrt" +
+                    "   LEFT JOIN FETCH rrt.resourceType rt" +
+                    "   LEFT JOIN FETCH rt.resourceTypeTranslations" +
+                    "   LEFT JOIN FETCH r.resourceTranslations" +
+                    "   WHERE r.publicId IN (:idSet)"
+    )
+    List<Resource> findByPublicIdIncludingCachedUrlsAndResourceTypesAndFiltersAndTranslations(Collection<URI> idSet);
+
     @Query("SELECT r.id FROM Resource r")
     List<Integer> getAllResourceIds();
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Queries.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Queries.java
@@ -31,7 +31,7 @@ public class Queries {
             @ApiParam(value = "ISO-639-1 language code", example = "nb")
             @RequestParam(value = "language", required = false, defaultValue = "") String language
     ) {
-        return resourceController.index(language, contentURI);
+        return resourceController.index(language, contentURI, null, null);
     }
 
     @GetMapping("/topics")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -74,11 +74,11 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
             contentUriFilter = null;
         }
 
-        if(key != null || value != null) {
+        if (key != null && value != null) {
             return resourceService.getResources(language, contentUriFilter, new MetadataKeyValueQuery(key, value));
-        } else {
-            return resourceService.getResources(language, contentUriFilter);
         }
+        return resourceService.getResources(language, contentUriFilter);
+
     }
 
     @GetMapping("{id}")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -74,7 +74,7 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
             contentUriFilter = null;
         }
 
-        if (key != null && value != null) {
+        if (key != null) {
             return resourceService.getResources(language, contentUriFilter, new MetadataKeyValueQuery(key, value));
         }
         return resourceService.getResources(language, contentUriFilter);

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -6,10 +6,7 @@ import no.ndla.taxonomy.domain.Resource;
 import no.ndla.taxonomy.repositories.ResourceRepository;
 import no.ndla.taxonomy.repositories.ResourceResourceTypeRepository;
 import no.ndla.taxonomy.rest.v1.commands.ResourceCommand;
-import no.ndla.taxonomy.service.CachedUrlUpdaterService;
-import no.ndla.taxonomy.service.MetadataApiService;
-import no.ndla.taxonomy.service.MetadataUpdateService;
-import no.ndla.taxonomy.service.ResourceService;
+import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.ResourceDTO;
 import no.ndla.taxonomy.service.dtos.ResourceTypeWithConnectionDTO;
 import no.ndla.taxonomy.service.dtos.ResourceWithParentTopicsDTO;
@@ -63,13 +60,25 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
 
             @RequestParam(value = "contentURI", required = false)
             @ApiParam(value = "Filter by contentUri")
-                    URI contentUriFilter
+                    URI contentUriFilter,
+
+            @ApiParam(value = "Filter by key and value")
+            @RequestParam(value = "key", required = false)
+                    String key,
+
+            @ApiParam(value = "Fitler by key and value")
+            @RequestParam(value = "value", required = false)
+                    String value
     ) {
         if (contentUriFilter != null && contentUriFilter.toString().equals("")) {
             contentUriFilter = null;
         }
 
-        return resourceService.getResources(language, contentUriFilter);
+        if(key != null || value != null) {
+            return resourceService.getResources(language, contentUriFilter, new MetadataKeyValueQuery(key, value));
+        } else {
+            return resourceService.getResources(language, contentUriFilter);
+        }
     }
 
     @GetMapping("{id}")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -74,7 +74,7 @@ public class Subjects extends CrudControllerWithMetadata<Subject> {
             @RequestParam(value = "value", required = false)
                     String value
     ) {
-        if (key != null && value != null) {
+        if (key != null) {
             return subjectService.getSubjects(language, new MetadataKeyValueQuery(key, value));
         }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -64,12 +64,21 @@ public class Subjects extends CrudControllerWithMetadata<Subject> {
     public List<SubjectIndexDocument> index(
             @ApiParam(value = "ISO-639-1 language code", example = "nb")
             @RequestParam(value = "language", required = false, defaultValue = "")
-                    String language
+                    String language,
+
+            @ApiParam(value = "Filter by key and value")
+            @RequestParam(value = "key", required = false)
+                    String key,
+
+            @ApiParam(value = "Fitler by key and value")
+            @RequestParam(value = "value", required = false)
+                    String value
     ) {
-        return subjectRepository.findAllIncludingCachedUrlsAndTranslations()
-                .stream()
-                .map(subject -> new SubjectIndexDocument(subject, language))
-                .collect(Collectors.toList());
+        if (key != null && value != null) {
+            return subjectService.getSubjects(language, new MetadataKeyValueQuery(key, value));
+        }
+
+        return subjectService.getSubjects(language);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -65,7 +65,7 @@ public class Topics extends CrudControllerWithMetadata<Topic> {
         if (contentUriFilter != null && contentUriFilter.toString().equals("")) {
             contentUriFilter = null;
         }
-        if (key != null && value != null) {
+        if (key != null) {
             return topicService.getTopics(language, contentUriFilter, new MetadataKeyValueQuery(key, value));
         }
         return topicService.getTopics(language, contentUriFilter);

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -33,7 +33,7 @@ public class Topics extends CrudControllerWithMetadata<Topic> {
                   ResourceService resourceService,
                   MetadataApiService metadataApiService,
                   MetadataUpdateService metadataUpdateService
-                  ) {
+    ) {
         super(topicRepository, cachedUrlUpdaterService, metadataApiService, metadataUpdateService);
 
         this.topicRepository = topicRepository;
@@ -65,12 +65,10 @@ public class Topics extends CrudControllerWithMetadata<Topic> {
         if (contentUriFilter != null && contentUriFilter.toString().equals("")) {
             contentUriFilter = null;
         }
-
-        if (key != null || value != null) {
+        if (key != null && value != null) {
             return topicService.getTopics(language, contentUriFilter, new MetadataKeyValueQuery(key, value));
-        } else {
-            return topicService.getTopics(language, contentUriFilter);
         }
+        return topicService.getTopics(language, contentUriFilter);
     }
 
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/topics/ResourceIndexDocument.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/topics/ResourceIndexDocument.java
@@ -15,6 +15,7 @@ import no.ndla.taxonomy.service.dtos.ResourceTypeDTO;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 /**
@@ -37,7 +38,7 @@ public class ResourceIndexDocument implements TopicTreeSorter.Sortable {
 
     @JsonProperty
     @ApiModelProperty(value = "Resource type(s)", example = "[{\"id\":\"urn:resourcetype:1\", \"name\":\"lecture\"}]")
-    public Set<ResourceTypeDTO> resourceTypes = new HashSet<>();
+    public Set<ResourceTypeDTO> resourceTypes = new TreeSet<>();
 
     @JsonProperty
     @ApiModelProperty(value = "The ID of this resource in the system where the content is stored. ",
@@ -99,7 +100,7 @@ public class ResourceIndexDocument implements TopicTreeSorter.Sortable {
             this.resourceTypes = resource.getResourceResourceTypes().stream()
                     .map(ResourceResourceType::getResourceType)
                     .map(resourceType -> new ResourceTypeDTO(resourceType, language))
-                    .collect(Collectors.toSet());
+                    .collect(Collectors.toCollection(TreeSet::new));
 
             this.contentUri = resource.getContentUri();
             this.path = resource.getPrimaryPath().orElse(null);

--- a/src/main/java/no/ndla/taxonomy/service/MetadataApiServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/MetadataApiServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URLEncoder;
@@ -109,7 +110,16 @@ public class MetadataApiServiceImpl implements MetadataApiService {
     }
 
     private List<MetadataDto> doBulkRead(String key, String value) {
-        return doBulkRead(getServiceUrl() + "/v1/taxonomy_entities/?key=" + URLEncoder.encode(key, StandardCharsets.UTF_8) + "&value=" + URLEncoder.encode(value, StandardCharsets.UTF_8));
+        var keyParam = key != null ? URLEncoder.encode(key, StandardCharsets.UTF_8) : null;
+        var valParam = value != null ? URLEncoder.encode(value, StandardCharsets.UTF_8) : null;
+
+        var uriBuilder = UriComponentsBuilder
+                .fromUriString(getServiceUrl() + "/v1/taxonomy_entities/")
+                .queryParam("key", keyParam);
+
+        if (valParam != null) uriBuilder = uriBuilder.queryParam("value", valParam);
+
+        return doBulkRead(uriBuilder.toUriString());
     }
 
     @Override

--- a/src/main/java/no/ndla/taxonomy/service/ResourceService.java
+++ b/src/main/java/no/ndla/taxonomy/service/ResourceService.java
@@ -26,4 +26,6 @@ public interface ResourceService {
     ResourceWithParentTopicsDTO getResourceWithParentTopicsByPublicId(URI publicId, String languageCode);
 
     List<ResourceDTO> getResources(String languageCode, URI contentUriFilter);
+
+    List<ResourceDTO> getResources(String languageCode, URI contentUriFilter, MetadataKeyValueQuery metadataKeyValueQuery);
 }

--- a/src/main/java/no/ndla/taxonomy/service/ResourceServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ResourceServiceImpl.java
@@ -237,8 +237,8 @@ public class ResourceServiceImpl implements ResourceService {
                 .values()
                 .stream()
                 .flatMap(idChunk -> {
-                   final var resources = resourceRepository.findByPublicIdIncludingCachedUrlsAndResourceTypesAndFiltersAndTranslations(idChunk);
-                   return createDto(resources, languageCode).stream();
+                    final var resources = resourceRepository.findByPublicIdIncludingCachedUrlsAndResourceTypesAndFiltersAndTranslations(idChunk);
+                    return createDto(resources, languageCode).stream();
                 })
                 .filter(Objects::nonNull)
                 .filter(resource -> {

--- a/src/main/java/no/ndla/taxonomy/service/SubjectService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SubjectService.java
@@ -1,7 +1,13 @@
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.rest.v1.dtos.subjects.SubjectIndexDocument;
+
 import java.net.URI;
+import java.util.List;
 
 public interface SubjectService {
     void delete(URI publicId);
+
+    List<SubjectIndexDocument> getSubjects(String languageCode, MetadataKeyValueQuery metadataKeyValueQuery);
+    List<SubjectIndexDocument> getSubjects(String languageCode);
 }

--- a/src/main/java/no/ndla/taxonomy/service/TopicServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/TopicServiceImpl.java
@@ -101,7 +101,7 @@ public class TopicServiceImpl implements TopicService {
                 .collect(Collectors.toList());
     }
 
-        @Override
+    @Override
     @InjectMetadata
     public List<ConnectionIndexDTO> getAllConnections(URI topicPublicId) {
         final var topic = topicRepository.findFirstByPublicId(topicPublicId).orElseThrow(() -> new NotFoundServiceException("Topic was not found"));

--- a/src/main/java/no/ndla/taxonomy/service/dtos/ResourceDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/ResourceDTO.java
@@ -12,6 +12,7 @@ import no.ndla.taxonomy.service.MetadataIdField;
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 @ApiModel("Resource")
@@ -41,7 +42,7 @@ public class ResourceDTO {
 
     @JsonProperty
     @ApiModelProperty(value = "Resource type(s)", example = "[{\"id\": \"urn:resourcetype:1\",\"name\":\"lecture\"}]")
-    private Set<ResourceTypeDTO> resourceTypes = new HashSet<>();
+    private TreeSet<ResourceTypeDTO> resourceTypes = new TreeSet<>();
 
     @JsonProperty
     @ApiModelProperty(value = "Filters this resource is associated with, directly or by inheritance", example = "[{\"id\":\"urn:filter:1\", \"relevanceId\":\"urn:relevance:core\"}]")
@@ -69,7 +70,7 @@ public class ResourceDTO {
         this.resourceTypes = resource.getResourceResourceTypes()
                 .stream()
                 .map(resourceType -> new ResourceTypeWithConnectionDTO(resourceType, languageCode))
-                .collect(Collectors.toSet());
+                .collect(Collectors.toCollection(TreeSet::new));
 
         this.path = resource.getPrimaryPath().orElse(null);
         this.paths = resource.getAllPaths();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/ResourceTypeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/ResourceTypeDTO.java
@@ -55,8 +55,7 @@ public class ResourceTypeDTO implements Comparable<ResourceTypeDTO> {
     @Override
     public int compareTo(ResourceTypeDTO o) {
         // We want to sort resourceTypes without parents first when sorting
-        if(this.parentId == o.parentId) return 0;
-        else if(this.parentId == null) return -1;
+        if(this.parentId == null && o.parentId != null) return -1;
         return 1;
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/dtos/ResourceTypeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/ResourceTypeDTO.java
@@ -9,7 +9,7 @@ import no.ndla.taxonomy.domain.ResourceTypeTranslation;
 import java.net.URI;
 
 @ApiModel("ResourceType")
-public class ResourceTypeDTO {
+public class ResourceTypeDTO implements Comparable<ResourceTypeDTO> {
     @JsonProperty
     @ApiModelProperty(example = "urn:resourcetype:2")
     private URI id;
@@ -50,5 +50,13 @@ public class ResourceTypeDTO {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public int compareTo(ResourceTypeDTO o) {
+        // We want to sort resourceTypes without parents first when sorting
+        if(this.parentId == o.parentId) return 0;
+        else if(this.parentId == null) return -1;
+        return 1;
     }
 }


### PR DESCRIPTION
Fixes NDLANO/Issues#2706

Legger til key/value parameterene til `/v1/resources` og `/v1/sujects` endepunktene.
Fikser også slik at endepunktene ikke tryner dersom man ikke oppgir både key og value.

Tar også å hiver inn en sortering på `ResourceTypeDTO` slik at ressurstyper uten parents kommer først i listene.