### PR TITLE
Returns relevance from parent connections.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/dtos/TopicDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TopicDTO.java
@@ -4,11 +4,14 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import no.ndla.taxonomy.domain.Relevance;
 import no.ndla.taxonomy.domain.Topic;
+import no.ndla.taxonomy.domain.TopicSubtopic;
 import no.ndla.taxonomy.domain.TopicTranslation;
 import no.ndla.taxonomy.service.MetadataIdField;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.Set;
 
 @ApiModel("Topic")
@@ -38,6 +41,10 @@ public class TopicDTO {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private MetadataDto metadata;
 
+    @JsonProperty
+    @ApiModelProperty(value = "Relevance id", example = "urn:relevance:core")
+    public URI relevanceId;
+
     public TopicDTO() {
 
     }
@@ -53,6 +60,9 @@ public class TopicDTO {
         this.name = topic.getTranslation(languageCode)
                 .map(TopicTranslation::getName)
                 .orElse(topic.getName());
+
+        Optional<Relevance> relevance = topic.getParentTopicSubtopic().flatMap(TopicSubtopic::getRelevance);
+        this.relevanceId = relevance.isPresent() ? relevance.get().getPublicId() : URI.create("urn:relevance:core");
     }
 
     public URI getId() {

--- a/src/main/java/no/ndla/taxonomy/service/dtos/TopicDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TopicDTO.java
@@ -62,7 +62,7 @@ public class TopicDTO {
                 .orElse(topic.getName());
 
         Optional<Relevance> relevance = topic.getParentTopicSubtopic().flatMap(TopicSubtopic::getRelevance);
-        this.relevanceId = relevance.isPresent() ? relevance.get().getPublicId() : URI.create("urn:relevance:core");
+        this.relevanceId = relevance.map(Relevance::getPublicId).orElse(URI.create("urn:relevance:core"));
     }
 
     public URI getId() {

--- a/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
@@ -28,7 +28,7 @@ public class TopicWithResourceConnectionDTO extends TopicDTO {
         this.isPrimary = topicResource.isPrimary().orElse(false);
         this.connectionId = topicResource.getPublicId();
         this.rank = topicResource.getRank();
-        this.relevanceId = topicResource.getRelevance().isPresent() ? topicResource.getRelevance().get().getPublicId() : URI.create("urn:relevance:core");
+        this.relevanceId = topicResource.getRelevance().map(Relevance::getPublicId).orElse(URI.create("urn:relevance:core"));
     }
 
     public TopicWithResourceConnectionDTO() {

--- a/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
@@ -3,6 +3,7 @@ package no.ndla.taxonomy.service.dtos;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiParam;
+import no.ndla.taxonomy.domain.Relevance;
 import no.ndla.taxonomy.domain.TopicResource;
 
 import java.net.URI;

--- a/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TopicWithResourceConnectionDTO.java
@@ -19,12 +19,16 @@ public class TopicWithResourceConnectionDTO extends TopicDTO {
     @ApiParam
     private int rank;
 
+    @ApiParam
+    private URI relevanceId;
+
     public TopicWithResourceConnectionDTO(TopicResource topicResource, String language) {
         super(topicResource.getTopic().orElseThrow(), language);
 
         this.isPrimary = topicResource.isPrimary().orElse(false);
         this.connectionId = topicResource.getPublicId();
         this.rank = topicResource.getRank();
+        this.relevanceId = topicResource.getRelevance().isPresent() ? topicResource.getRelevance().get().getPublicId() : URI.create("urn:relevance:core");
     }
 
     public TopicWithResourceConnectionDTO() {


### PR DESCRIPTION
NDLANO/Issues#2757

For å kunne vise om emne og ressurs er tilleggstoff inne på sjølve artikkelen. For ressurs må også graphql-api oppdateres for å hente dataene.