### PR TITLE
2854 version handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
+        <spring.cloud.version>2.3.2</spring.cloud.version>
         <springfox.version>2.9.2</springfox.version>
         <javamelody.version>1.87.0</javamelody.version>
     </properties>
@@ -31,7 +32,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Hoxton.SR1</version>
+                <version>2020.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -168,6 +169,18 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-context</artifactId>
+            <version>${spring.cloud.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-autoconfigure</artifactId>
+            <version>${spring.cloud.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/src/main/java/no/ndla/taxonomy/config/SwaggerConfiguration.java
+++ b/src/main/java/no/ndla/taxonomy/config/SwaggerConfiguration.java
@@ -11,10 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.ApiKey;
-import springfox.documentation.service.AuthorizationScope;
-import springfox.documentation.service.SecurityReference;
+import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
@@ -65,6 +62,7 @@ public class SwaggerConfiguration {
                 + "Unless otherwise specified, all PUT and POST requests must use Content-Type: application/json;charset=UTF-8. If charset is omitted, UTF-8 will be assumed. All GET requests will return data using the same content type.\n\n"
                 + "When you remove an entity, its associations are also deleted. E.g., if you remove a subject, its associations to any topics are removed. The topics themselves are not affected.\n\n"
                 + "If you are using Swagger in an environment that requires authentication you will need a valid JWT token to PUT/POST/DELETE. Apply this by typing 'Bearer [YOUR TOKEN]' in the 'Authorize' dialog",
-                "v1", null, null, "GPL 3.0", "https://www.gnu.org/licenses/gpl-3.0.en.html", emptyList());
+                "v1", "https://om.ndla.no/tos", new Contact("NDLA", "ndla.no", "support+api@ndla.no"), "GPL 3.0",
+                "https://www.gnu.org/licenses/gpl-3.0.en.html", emptyList());
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/Version.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Version.java
@@ -1,0 +1,68 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.domain;
+
+import org.springframework.data.annotation.CreatedDate;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import java.net.URI;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+public class Version extends DomainEntity {
+    @Column
+    @Enumerated(EnumType.STRING)
+    private VersionType versionType = VersionType.BETA;
+
+    @Column
+    @CreatedDate
+    private Instant created;
+
+    @Column
+    private Instant published;
+
+    @Column
+    private Instant archived;
+
+    public Version() {
+        created = Instant.now();
+        setPublicId(URI.create("urn:version:" + UUID.randomUUID()));
+    }
+
+    public VersionType getVersionType() {
+        return versionType;
+    }
+
+    public void setVersionType(VersionType versionType) {
+        this.versionType = versionType;
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    public Instant getPublished() {
+        return published;
+    }
+
+    public void setPublished(Instant published) {
+        this.published = published;
+    }
+
+    public Instant getArchived() {
+        return archived;
+    }
+
+    public void setArchived(Instant archived) {
+        this.archived = archived;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/domain/Version.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Version.java
@@ -7,7 +7,7 @@
 
 package no.ndla.taxonomy.domain;
 
-import org.springframework.data.annotation.CreatedDate;
+import no.ndla.taxonomy.util.HashUtil;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -24,8 +24,10 @@ public class Version extends DomainEntity {
     private VersionType versionType = VersionType.BETA;
 
     @Column
-    @CreatedDate
-    private Instant created;
+    private String name;
+
+    @Column
+    private final String hash;
 
     @Column
     private Instant published;
@@ -34,8 +36,8 @@ public class Version extends DomainEntity {
     private Instant archived;
 
     public Version() {
-        created = Instant.now();
         setPublicId(URI.create("urn:version:" + UUID.randomUUID()));
+        this.hash = HashUtil.shortHash(getPublicId());
     }
 
     public VersionType getVersionType() {
@@ -46,8 +48,16 @@ public class Version extends DomainEntity {
         this.versionType = versionType;
     }
 
-    public Instant getCreated() {
-        return created;
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getHash() {
+        return hash;
     }
 
     public Instant getPublished() {

--- a/src/main/java/no/ndla/taxonomy/domain/VersionType.java
+++ b/src/main/java/no/ndla/taxonomy/domain/VersionType.java
@@ -1,0 +1,12 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.domain;
+
+public enum VersionType {
+    BETA, PUBLISHED, ARCHIVED
+}

--- a/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
@@ -1,0 +1,21 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.repositories;
+
+import no.ndla.taxonomy.domain.Version;
+import no.ndla.taxonomy.domain.VersionType;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.Set;
+
+public interface VersionRepository extends TaxonomyRepository<Version> {
+    Optional<Version> findFirstByPublicId(URI publicId);
+
+    Optional<Version> findByVersionType(VersionType versionType);
+}

--- a/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
@@ -11,11 +11,15 @@ import no.ndla.taxonomy.domain.Version;
 import no.ndla.taxonomy.domain.VersionType;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface VersionRepository extends TaxonomyRepository<Version> {
     Optional<Version> findFirstByPublicId(URI publicId);
 
-    Optional<Version> findByVersionType(VersionType versionType);
+    Optional<Version> findFirstByHash(String hash);
+
+    List<Version> findByVersionType(VersionType versionType);
+
+    Optional<Version> findFirstByVersionType(VersionType versionType);
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -8,7 +8,7 @@
 package no.ndla.taxonomy.rest.v1;
 
 import io.swagger.annotations.ApiOperation;
-import no.ndla.taxonomy.domain.DomainObject;
+import no.ndla.taxonomy.domain.DomainEntity;
 import no.ndla.taxonomy.domain.EntityWithPath;
 import no.ndla.taxonomy.domain.exceptions.DuplicateIdException;
 import no.ndla.taxonomy.repositories.TaxonomyRepository;
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Transactional
-public abstract class CrudController<T extends DomainObject> {
+public abstract class CrudController<T extends DomainEntity> {
     protected TaxonomyRepository<T> repository;
     protected CachedUrlUpdaterService cachedUrlUpdaterService;
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -178,7 +178,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
 
     @DeleteMapping("/{id}")
     @ApiOperation(value = "Deletes a single entity by id")
-    @PreAuthorize("hasAuthority('TAXONOMY_WRITE')")
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable("id") URI id) {
         nodeService.delete(id);

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -59,7 +59,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
     public List<EntityWithPathDTO> index(
             @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", required = false, defaultValue = "") String language,
             @ApiParam(value = "Filter by key and value") @RequestParam(value = "key", required = false) String key,
-            @ApiParam(value = "Fitler by key and value") @RequestParam(value = "value", required = false) String value) {
+            @ApiParam(value = "Filter by key and value") @RequestParam(value = "value", required = false) String value) {
         if (key != null) {
             return nodeService.getNodes(language, NodeType.SUBJECT, null, new MetadataKeyValueQuery(key, value));
         }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
@@ -26,6 +26,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
@@ -87,5 +88,17 @@ public class Versions extends CrudController<Version> {
             throw new InvalidArgumentServiceException("Version has wrong type");
         }
         versionService.publishBetaAndArchiveCurrent(id);
+    }
+
+    @PutMapping("/{id}/generate")
+    @ApiOperation("Generates files for a beta version")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
+    public void generate(@PathVariable("id") URI id) throws IOException {
+        Version version = versionRepository.getByPublicId(id);
+        if (version == null || version.getVersionType() != VersionType.BETA) {
+            throw new InvalidArgumentServiceException("Cannot update production version");
+        }
+        versionService.generateFilesForAllEndpoints(id);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
@@ -1,0 +1,72 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.rest.v1;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import no.ndla.taxonomy.domain.Version;
+import no.ndla.taxonomy.domain.VersionType;
+import no.ndla.taxonomy.repositories.VersionRepository;
+import no.ndla.taxonomy.rest.NotFoundHttpResponseException;
+import no.ndla.taxonomy.rest.v1.commands.SubjectCommand;
+import no.ndla.taxonomy.rest.v1.commands.VersionCommand;
+import no.ndla.taxonomy.service.VersionService;
+import no.ndla.taxonomy.service.dtos.VersionDTO;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+@RequestMapping(path = { "/v1/versions" })
+public class Versions extends CrudController<Version> {
+    private final VersionRepository versionRepository;
+    private final VersionService versionService;
+
+    public Versions(VersionService versionService, VersionRepository versionRepository) {
+        super(versionRepository);
+        this.versionService = versionService;
+        this.versionRepository = versionRepository;
+    }
+
+    @GetMapping
+    @ApiOperation("Gets all versions")
+    public List<VersionDTO> getAll(
+            @ApiParam(value = "Version type", example = "PUBLISHED") @RequestParam(value = "type", required = false, defaultValue = "") VersionType versionType) {
+        if (versionType != null)
+            return versionService.getVersionsOfType(versionType);
+        return versionService.getVersions();
+    }
+
+    @GetMapping("/{id}")
+    @ApiOperation(value = "Gets a single version")
+    public VersionDTO get(@PathVariable("id") URI id) {
+        return versionRepository.findFirstByPublicId(id).map(VersionDTO::new)
+                .orElseThrow(() -> new NotFoundHttpResponseException("Version not found"));
+    }
+
+    @PostMapping
+    @ApiOperation(value = "Creates a new version")
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
+    public ResponseEntity<Void> post(
+            @ApiParam(name = "version", value = "The new version") @RequestBody VersionCommand command) {
+        final var version = new Version();
+        return doPost(version, command);
+    }
+
+    @PutMapping("/{id}")
+    @ApiOperation("Updates a version")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
+    public void put(@PathVariable("id") URI id, @ApiParam(name = "subject", value = "The updated version.") @RequestBody VersionCommand command) {
+        doPut(id, command);
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/rest/v1/commands/VersionCommand.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/commands/VersionCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.rest.v1.commands;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModelProperty;
+import no.ndla.taxonomy.domain.Version;
+import no.ndla.taxonomy.service.UpdatableDto;
+
+import java.net.URI;
+import java.util.Optional;
+
+public class VersionCommand implements UpdatableDto<Version> {
+    @JsonProperty
+    @ApiModelProperty(notes = "If specified, set the id to this value. Must start with urn:subject: and be a valid URI. If ommitted, an id will be assigned automatically.", example = "urn:subject:1")
+    public URI id;
+
+    @Override
+    public Optional<URI> getId() {
+        return Optional.ofNullable(id);
+    }
+
+    @Override
+    public void apply(Version entity) {
+        if (getId().isPresent())
+            entity.setPublicId(id);
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/rest/v1/commands/VersionCommand.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/commands/VersionCommand.java
@@ -20,6 +20,10 @@ public class VersionCommand implements UpdatableDto<Version> {
     @ApiModelProperty(notes = "If specified, set the id to this value. Must start with urn:subject: and be a valid URI. If ommitted, an id will be assigned automatically.", example = "urn:subject:1")
     public URI id;
 
+    @JsonProperty
+    @ApiModelProperty(notes = "If specified, set the name to this value.", example = "Beta 2022")
+    public String name;
+
     @Override
     public Optional<URI> getId() {
         return Optional.ofNullable(id);
@@ -29,5 +33,8 @@ public class VersionCommand implements UpdatableDto<Version> {
     public void apply(Version entity) {
         if (getId().isPresent())
             entity.setPublicId(id);
+        if (name != null) {
+            entity.setName(name);
+        }
     }
 }

--- a/src/main/java/no/ndla/taxonomy/security/JWTAuthentication.java
+++ b/src/main/java/no/ndla/taxonomy/security/JWTAuthentication.java
@@ -22,6 +22,7 @@ public class JWTAuthentication implements Authentication {
     private static final long serialVersionUID = 1L;
     private static final String TAXONOMY_API = "taxonomy";
     private static final String WRITE_PERMISSION = "write";
+    private static final String ADMIN_PERMISSION = "admin";
     private static final String PRODUCTION = "prod";
 
     private Collection<GrantedAuthority> authorities;
@@ -41,9 +42,11 @@ public class JWTAuthentication implements Authentication {
                 for (String jwtPermissionString : allPermissions) {
                     final JWTPermission jwtPermission = new JWTPermission(jwtPermissionString);
                     if (jwtPermission.getApi() != null && jwtPermission.getPermission() != null
-                            && jwtPermission.getApi().equals(TAXONOMY_API)
-                            && jwtPermission.getPermission().equals(WRITE_PERMISSION)) {
-                        tmp.add(new SimpleGrantedAuthority("TAXONOMY_WRITE"));
+                            && jwtPermission.getApi().equals(TAXONOMY_API)) {
+                        if (jwtPermission.getPermission().equals(WRITE_PERMISSION))
+                            tmp.add(new SimpleGrantedAuthority("TAXONOMY_WRITE"));
+                        if (jwtPermission.getPermission().equals(ADMIN_PERMISSION))
+                            tmp.add(new SimpleGrantedAuthority("TAXONOMY_ADMIN"));
                     }
                 }
             }

--- a/src/main/java/no/ndla/taxonomy/service/VersionFileGeneratorService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionFileGeneratorService.java
@@ -1,0 +1,65 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service;
+
+import no.ndla.taxonomy.domain.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.*;
+
+@Service
+@Profile("junit")
+public class VersionFileGeneratorService implements VersionGeneratorService {
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Value(value = "${versions.files.folder:file:/tmp}")
+    private String rootFolder;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${server.port:5000}")
+    private int serverPort;
+
+    @Override
+    @Async
+    public void generateJson(Version version) {
+        // generateJsonForApiEndpoints(version, restTemplate, serverPort); // Only to test local generation of all files
+        try {
+            writeFile(rootFolder, "test.json", "{\"key\":\"value\"}".getBytes(), null);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void writeFile(String directory, String filename, byte[] filecontent, String contentType)
+            throws IOException {
+        File file = new File(rootFolder + "/" + directory + filename);
+        file.getParentFile().mkdirs();
+
+        InputStream stream = new ByteArrayInputStream(filecontent);
+        String filepath = file.getPath();
+        OutputStream bos = new FileOutputStream(filepath);
+        int bytesRead;
+        byte[] buffer = new byte[8192];
+
+        while ((bytesRead = stream.read(buffer, 0, 8192)) != -1) {
+            bos.write(buffer, 0, bytesRead);
+        }
+        bos.close();
+        // close the stream
+        stream.close();
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/VersionGeneratorService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionGeneratorService.java
@@ -1,0 +1,64 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import no.ndla.taxonomy.domain.Version;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Map;
+
+public interface VersionGeneratorService {
+
+    @Async
+    default void generateJsonForApiEndpoints(Version version, RestTemplate restTemplate, int serverPort) {
+        String[] types = { "filters", "relevances", "subjects", "topics", "resources", "nodes",
+                "resource-resourcetypes", "resource-types", "subject-topics", "topic-resources", "topic-subtopics" };
+        Map<String, String[]> subs = Map.of("subjects",
+                new String[] { "metadata", "topics", "resources", "translations" }, "topics",
+                new String[] { "metadata", "resources", "connections", "translations" }, "resources",
+                new String[] { "metadata", "full", "resource-types", "translations" }, "nodes",
+                new String[] { "metadata", "connections", "resources", "nodes" });
+        String baseUrl = "http://localhost:" + serverPort;
+        try {
+            for (String type : types) {
+                String path = "/v1/" + type;
+                JsonNode response = restTemplate.getForObject(baseUrl + path, JsonNode.class);
+                writeFile(version.getPublicId().toString(), path + ".json", response.toString().getBytes(), null);
+                response.elements().forEachRemaining(r -> {
+                    try {
+                        String id = r.get("id").textValue();
+                        String subPath = path + "/" + id;
+                        JsonNode subResponse = restTemplate.getForObject(baseUrl + subPath, JsonNode.class);
+                        writeFile(version.getPublicId().toString(), subPath + ".json",
+                                subResponse.toString().getBytes(), null);
+                        if (subs.get(type) != null) {
+                            for (String sub : subs.get(type)) {
+                                String subSubPath = subPath + "/" + sub;
+                                JsonNode subSubResponse = restTemplate.getForObject(baseUrl + subSubPath,
+                                        JsonNode.class);
+                                writeFile(version.getPublicId().toString(), subSubPath + ".json",
+                                        subSubResponse.toString().getBytes(), null);
+                            }
+                        }
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
+                });
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    void generateJson(Version version);
+
+    void writeFile(String directory, String filename, byte[] filecontent, String contentType) throws IOException;
+}

--- a/src/main/java/no/ndla/taxonomy/service/VersionS3GeneratorService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionS3GeneratorService.java
@@ -1,0 +1,91 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import no.ndla.taxonomy.domain.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+
+@Service
+@Profile("!junit")
+public class VersionS3GeneratorService implements VersionGeneratorService {
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Autowired
+    private AmazonS3 s3Attachment;
+
+    @Value(value = "${taxonomy.versions.bucket:local.taxonomy-versions.ndla}")
+    private String bucketName;
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    @Value("${server.port:5000}")
+    private int serverPort;
+
+    @Override
+    @Async
+    public void generateJson(Version version) {
+        generateJsonForApiEndpoints(version, restTemplate, serverPort);
+    }
+
+    @Override
+    public void writeFile(String directory, String filename, byte[] filecontent, String contentType) {
+        if (filecontent == null || filecontent.length == 0) {
+            throw new RuntimeException("Filecontent is empty");
+        }
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(filecontent.length);
+        metadata.setContentType(contentType);
+
+        String path = directory + filename;
+
+        try {
+            // Generating PutObjectRequest
+            PutObjectRequest putAttachment = new PutObjectRequest(bucketName, path,
+                    new ByteArrayInputStream(filecontent), metadata);
+            putAttachment.withCannedAcl(CannedAccessControlList.PublicRead);
+
+            PutObjectResult putResult = s3Attachment.putObject(putAttachment);
+
+        } catch (AmazonServiceException ase) {
+            logger.warn("Caught an AmazonServiceException, which means your request made it "
+                    + "to Amazon S3, but was rejected with an error response for some reason.");
+            logger.warn("Error Message:    " + ase.getMessage());
+            logger.warn("HTTP Status Code: " + ase.getStatusCode());
+            logger.warn("AWS Error Code:   " + ase.getErrorCode());
+            logger.warn("Error Type:       " + ase.getErrorType());
+            logger.warn("Request ID:       " + ase.getRequestId());
+        } catch (AmazonClientException ace) {
+            logger.warn("Caught an AmazonClientException, which means the client encountered "
+                    + "a serious internal problem while trying to communicate with S3, "
+                    + "such as not being able to access the network.");
+            logger.warn("Error Message: " + ace.getMessage());
+        } catch (Exception e) {
+            logger.warn("Caught an exception");
+            logger.warn("Error message:" + e.getMessage());
+            logger.warn("Stack trace:" + Arrays.toString(e.getStackTrace()));
+        }
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/VersionService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionService.java
@@ -1,0 +1,48 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service;
+
+import no.ndla.taxonomy.domain.VersionType;
+import no.ndla.taxonomy.repositories.VersionRepository;
+import no.ndla.taxonomy.service.dtos.SubjectDTO;
+import no.ndla.taxonomy.service.dtos.VersionDTO;
+import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Transactional(readOnly = true)
+@Service
+public class VersionService {
+    private final VersionRepository versionRepository;
+
+    public VersionService(VersionRepository versionRepository) {
+        this.versionRepository = versionRepository;
+    }
+
+    @Transactional
+    public void delete(URI publicId) {
+        final var subjectToDelete = versionRepository.findFirstByPublicId(publicId)
+                .orElseThrow(() -> new NotFoundServiceException("Subject was not found"));
+
+        versionRepository.delete(subjectToDelete);
+        versionRepository.flush();
+    }
+
+    public List<VersionDTO> getVersions() {
+        return versionRepository.findAll().stream().map(VersionDTO::new).collect(Collectors.toList());
+    }
+
+    public List<VersionDTO> getVersionsOfType(VersionType versionType) {
+        return versionRepository.findByVersionType(versionType).stream().map(VersionDTO::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/VersionService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionService.java
@@ -10,12 +10,12 @@ package no.ndla.taxonomy.service;
 import no.ndla.taxonomy.domain.Version;
 import no.ndla.taxonomy.domain.VersionType;
 import no.ndla.taxonomy.repositories.VersionRepository;
-import no.ndla.taxonomy.service.dtos.SubjectDTO;
 import no.ndla.taxonomy.service.dtos.VersionDTO;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.List;
@@ -26,9 +26,11 @@ import java.util.stream.Collectors;
 @Service
 public class VersionService {
     private final VersionRepository versionRepository;
+    private VersionGeneratorService versionJsonGeneratorService;
 
-    public VersionService(VersionRepository versionRepository) {
+    public VersionService(VersionRepository versionRepository, VersionGeneratorService versionJsonGeneratorService) {
         this.versionRepository = versionRepository;
+        this.versionJsonGeneratorService = versionJsonGeneratorService;
     }
 
     @Transactional
@@ -61,5 +63,10 @@ public class VersionService {
         beta.setVersionType(VersionType.PUBLISHED);
         beta.setPublished(Instant.now());
         versionRepository.save(beta);
+    }
+
+    public void generateFilesForAllEndpoints(URI id) throws IOException {
+        Version beta = versionRepository.getByPublicId(id);
+        versionJsonGeneratorService.generateJson(beta);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/VersionService.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionService.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.domain.Version;
 import no.ndla.taxonomy.domain.VersionType;
 import no.ndla.taxonomy.repositories.VersionRepository;
 import no.ndla.taxonomy.service.dtos.SubjectDTO;
@@ -16,7 +17,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Transactional(readOnly = true)
@@ -44,5 +47,19 @@ public class VersionService {
     public List<VersionDTO> getVersionsOfType(VersionType versionType) {
         return versionRepository.findByVersionType(versionType).stream().map(VersionDTO::new)
                 .collect(Collectors.toList());
+    }
+
+    public void publishBetaAndArchiveCurrent(URI id) {
+        Optional<Version> published = versionRepository.findFirstByVersionType(VersionType.PUBLISHED);
+        if (published.isPresent()) {
+            Version version = published.get();
+            version.setVersionType(VersionType.ARCHIVED);
+            version.setArchived(Instant.now());
+            versionRepository.save(version);
+        }
+        Version beta = versionRepository.getByPublicId(id);
+        beta.setVersionType(VersionType.PUBLISHED);
+        beta.setPublished(Instant.now());
+        versionRepository.save(beta);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/dtos/VersionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/VersionDTO.java
@@ -1,0 +1,74 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.service.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import no.ndla.taxonomy.domain.Version;
+import no.ndla.taxonomy.domain.VersionType;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import java.net.URI;
+import java.time.Instant;
+
+@ApiModel("Version")
+public class VersionDTO {
+    @JsonProperty
+    @ApiModelProperty(example = "urn:version:1")
+    private URI id;
+
+    @JsonProperty
+    @ApiModelProperty(example = "BETA")
+    @Enumerated(EnumType.STRING)
+    private VersionType versionType;
+
+    @JsonProperty
+    @ApiModelProperty(notes = "Timestamp for when version was created")
+    private Instant created;
+
+    @JsonProperty
+    @ApiModelProperty(notes = "Timestamp for when version was published")
+    private Instant published;
+
+    @JsonProperty
+    @ApiModelProperty(notes = "Timestamp for when version was archived")
+    private Instant archived;
+
+    public VersionDTO() {
+    }
+
+    public VersionDTO(Version version) {
+        this.id = version.getPublicId();
+        this.versionType = version.getVersionType();
+        this.created = version.getCreated();
+        this.published = version.getPublished();
+        this.archived = version.getArchived();
+    }
+
+    public URI getId() {
+        return id;
+    }
+
+    public VersionType getVersionType() {
+        return versionType;
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    public Instant getPublished() {
+        return published;
+    }
+
+    public Instant getArchived() {
+        return archived;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/dtos/VersionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/VersionDTO.java
@@ -30,8 +30,12 @@ public class VersionDTO {
     private VersionType versionType;
 
     @JsonProperty
-    @ApiModelProperty(notes = "Timestamp for when version was created")
-    private Instant created;
+    @ApiModelProperty(notes = "Name for the version")
+    private String name;
+
+    @JsonProperty
+    @ApiModelProperty(notes = "Unique hash for the version")
+    private String hash;
 
     @JsonProperty
     @ApiModelProperty(notes = "Timestamp for when version was published")
@@ -47,7 +51,8 @@ public class VersionDTO {
     public VersionDTO(Version version) {
         this.id = version.getPublicId();
         this.versionType = version.getVersionType();
-        this.created = version.getCreated();
+        this.name = version.getName();
+        this.hash = version.getHash();
         this.published = version.getPublished();
         this.archived = version.getArchived();
     }
@@ -60,8 +65,12 @@ public class VersionDTO {
         return versionType;
     }
 
-    public Instant getCreated() {
-        return created;
+    public String getName() {
+        return name;
+    }
+
+    public String getHash() {
+        return hash;
     }
 
     public Instant getPublished() {

--- a/src/main/java/no/ndla/taxonomy/util/HashUtil.java
+++ b/src/main/java/no/ndla/taxonomy/util/HashUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.util;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * Util for generating hashes in different lengths
+ */
+public class HashUtil {
+    private static String generateHash(Object original, int length) {
+        String hash = new DigestUtils("SHA3-256").digestAsHex(original.toString());
+        if (length > 0)
+            return hash.substring(0, length);
+        return hash;
+    }
+
+    public static String shortHash(Object original) {
+        return generateHash(original, 4);
+    }
+
+    public static String mediumHash(Object original) {
+        return generateHash(original, 8);
+    }
+
+    public static String longHash(Object original) {
+        return generateHash(original, 16);
+    }
+
+    public static String fullHash(Object original) {
+        return generateHash(original, 0);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,11 @@ management:
 
 ndla.taxonomy-metadata.url: http://taxonomy-metadata
 
+cloud:
+  aws:
+    region:
+      static: eu-west-1
+
 ---
 
 spring:

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1011,8 +1011,11 @@
             <column name="version_type" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created" type="timestamp with time zone">
-                <constraints nullable="false"/>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="hash" type="varchar(255)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="version_hash"/>
             </column>
             <column name="published" type="timestamp with time zone">
                 <constraints nullable="true"/>

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -999,4 +999,27 @@
             FROM topic_resource tr;
         </sql>
     </changeSet>
+
+    <changeSet id="20211110 add version table" author="Gunnar Velle">
+        <createTable tableName="version">
+            <column name="id" type="serial" autoIncrement="true">
+                <constraints primaryKey="true" uniqueConstraintName="version_pkey"/>
+            </column>
+            <column name="public_id" type="varchar(255)">
+                <constraints nullable="false" unique="true" uniqueConstraintName="version_public_id"/>
+            </column>
+            <column name="version_type" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="timestamp with time zone">
+                <constraints nullable="false"/>
+            </column>
+            <column name="published" type="timestamp with time zone">
+                <constraints nullable="true"/>
+            </column>
+            <column name="archived" type="timestamp with time zone">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/JWTTokenTest.java
+++ b/src/test/java/no/ndla/taxonomy/JWTTokenTest.java
@@ -21,12 +21,13 @@ import static org.mockito.Mockito.when;
 
 public class JWTTokenTest {
 
-    String authorizationHeader = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjoicjBnSGI5WGczbGk0eXlYdjBRU0dRY3pWM2J2aWFrclQiLCJpc3MiOiJodHRwczovL25kbGEuZXUuYXV0aDAuY29tLyIsInN1YiI6InIwZ0hiOVhnM2xpNHl5WHYwUVNHUWN6VjNidmlha3JUQGNsaWVudHMiLCJhdWQiOiJuZGxhX3N5c3RlbSIsImlhdCI6MTUxNTQ5NTUzMCwiZXhwIjoxNTE1NTgxOTMwLCJzY29wZSI6ImRyYWZ0cy1zdGFnaW5nOndyaXRlIGFydGljbGVzLXRlc3Q6cHVibGlzaCBpbWFnZXMtcHJvZDp3cml0ZSBsaXN0aW5nLXRlc3Q6d3JpdGUgYXJ0aWNsZXMtYnJ1a2VydGVzdDp3cml0ZSBsaXN0aW5nLXByb2Q6d3JpdGUgYXJ0aWNsZXMtdGVzdDp3cml0ZSBhcnRpY2xlcy1zdGFnaW5nOndyaXRlIGxpc3RpbmctYnJ1a2VydGVzdDp3cml0ZSBpbWFnZXMtc3RhZ2luZzp3cml0ZSBpbWFnZXMtdGVzdDp3cml0ZSBhcnRpY2xlcy1wcm9kOnB1Ymxpc2ggYXJ0aWNsZXMtYnJ1a2VydGVzdDpwdWJsaXNoIGRyYWZ0cy10ZXN0OnNldF90b19wdWJsaXNoIGxpc3Rpbmctc3RhZ2luZzp3cml0ZSBhdWRpby1icnVrZXJ0ZXN0OndyaXRlIGRyYWZ0cy1wcm9kOndyaXRlIGltYWdlcy1icnVrZXJ0ZXN0OndyaXRlIGRyYWZ0cy10ZXN0OndyaXRlIGF1ZGlvLXByb2Q6d3JpdGUgYXVkaW8tdGVzdDp3cml0ZSBhcnRpY2xlcy1zdGFnaW5nOnB1Ymxpc2ggYXJ0aWNsZXMtcHJvZDp3cml0ZSBkcmFmdHMtc3RhZ2luZzpzZXRfdG9fcHVibGlzaCBhdWRpby1zdGFnaW5nOndyaXRlIGRyYWZ0cy1icnVrZXJ0ZXN0OnNldF90b19wdWJsaXNoIGRyYWZ0cy1wcm9kOnNldF90b19wdWJsaXNoIGRyYWZ0cy1icnVrZXJ0ZXN0OndyaXRlIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.cOhrV1JshGYyD-CI-jh_omwy_ehDZJFq1P3C3FibhgcG2V3q6emPftmyOfKstp5_HxBWfULeq4p3Du5GlpJ5oADGSES2KlfSAZFQQWoN2auCqL4TP7lR7syosEftwWa6XIYMgzqk5r4KH4F0ay0v5n7_sU99r6HDDi8bsuLpgoXgcRwtx_SIh_CJWplS30Iiz8EdITdvknU40_t8zeqp7CoYnnZRQtm79qHxMGXyyiSqGPISUkzEK6O8HPNh0dVWvyI-SNzAQyJQg8J3RC26bgo7SpVDt8oGGMiKsBnssuXO60MqEs_vt3Q4-xdXIJQOj0YX4ICEeHJ3nq1pigWRLg";
-    String authorizationHeaderv2 = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6bEVPVFE1TTBOR01EazROakV4T0VKR01qYzJNalZGT0RoRVFrRTFOVUkyTmtFMFJUUXlSZyJ9.eyJpc3MiOiJodHRwczovL25kbGEtdGVzdC5ldS5hdXRoMC5jb20vIiwic3ViIjoiMjRaYmkyYjJycGdVVnZQNzFEV3ZTNUloVVk0ZlpGSjNAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiaWF0IjoxNTQ0NTIwMjg3LCJleHAiOjE1NDQ1MjIwODcsImF6cCI6IjI0WmJpMmIycnBnVVZ2UDcxRFd2UzVJaFVZNGZaRkozIiwic2NvcGUiOiJ0YXhvbm9teTp3cml0ZSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.Yon-Jm1RAe5jn0bS8NTQ2bIZWNAO-M3JN_G8PvxbuMtKLqOZ7SydAx9cgDysKg95HRj8tCVpj1fDttKSIm59Ww-400gmDTTlQPqdzlNWsXT7wgAllTboXEigGAmjj1tNKYFQxTdIa9azdiqUPT-e7ao5JOdM3_uYFiINC_MoxfFaezGSWeja4TkEakj8MyxGraKa6DhXrlLd1TfZtH6bv6mxEyAy_YmYZQ1vQ8iZKdGM1AHp703yoqITutrfzdZOx-yxNUcmPJwqzcm3cXd0RA-qwJ5NfsuZrS52NtrDqRaxGdIuai9W04nM5ZEfvkvpFGe8gU6fZ8is0ThiS39luQ";
+    String auth = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik9FSTFNVVU0T0RrNU56TTVNekkyTXpaRE9EazFOMFl3UXpkRE1EUXlPRFZDUXpRM1FUSTBNQSJ9.eyJodHRwczovL25kbGEubm8vY2xpZW50X2lkIjoicjBnSGI5WGczbGk0eXlYdjBRU0dRY3pWM2J2aWFrclQiLCJpc3MiOiJodHRwczovL25kbGEuZXUuYXV0aDAuY29tLyIsInN1YiI6InIwZ0hiOVhnM2xpNHl5WHYwUVNHUWN6VjNidmlha3JUQGNsaWVudHMiLCJhdWQiOiJuZGxhX3N5c3RlbSIsImlhdCI6MTUxNTQ5NTUzMCwiZXhwIjoxNTE1NTgxOTMwLCJzY29wZSI6ImRyYWZ0cy1zdGFnaW5nOndyaXRlIGFydGljbGVzLXRlc3Q6cHVibGlzaCBpbWFnZXMtcHJvZDp3cml0ZSBsaXN0aW5nLXRlc3Q6d3JpdGUgYXJ0aWNsZXMtYnJ1a2VydGVzdDp3cml0ZSBsaXN0aW5nLXByb2Q6d3JpdGUgYXJ0aWNsZXMtdGVzdDp3cml0ZSBhcnRpY2xlcy1zdGFnaW5nOndyaXRlIGxpc3RpbmctYnJ1a2VydGVzdDp3cml0ZSBpbWFnZXMtc3RhZ2luZzp3cml0ZSBpbWFnZXMtdGVzdDp3cml0ZSBhcnRpY2xlcy1wcm9kOnB1Ymxpc2ggYXJ0aWNsZXMtYnJ1a2VydGVzdDpwdWJsaXNoIGRyYWZ0cy10ZXN0OnNldF90b19wdWJsaXNoIGxpc3Rpbmctc3RhZ2luZzp3cml0ZSBhdWRpby1icnVrZXJ0ZXN0OndyaXRlIGRyYWZ0cy1wcm9kOndyaXRlIGltYWdlcy1icnVrZXJ0ZXN0OndyaXRlIGRyYWZ0cy10ZXN0OndyaXRlIGF1ZGlvLXByb2Q6d3JpdGUgYXVkaW8tdGVzdDp3cml0ZSBhcnRpY2xlcy1zdGFnaW5nOnB1Ymxpc2ggYXJ0aWNsZXMtcHJvZDp3cml0ZSBkcmFmdHMtc3RhZ2luZzpzZXRfdG9fcHVibGlzaCBhdWRpby1zdGFnaW5nOndyaXRlIGRyYWZ0cy1icnVrZXJ0ZXN0OnNldF90b19wdWJsaXNoIGRyYWZ0cy1wcm9kOnNldF90b19wdWJsaXNoIGRyYWZ0cy1icnVrZXJ0ZXN0OndyaXRlIiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIn0.cOhrV1JshGYyD-CI-jh_omwy_ehDZJFq1P3C3FibhgcG2V3q6emPftmyOfKstp5_HxBWfULeq4p3Du5GlpJ5oADGSES2KlfSAZFQQWoN2auCqL4TP7lR7syosEftwWa6XIYMgzqk5r4KH4F0ay0v5n7_sU99r6HDDi8bsuLpgoXgcRwtx_SIh_CJWplS30Iiz8EdITdvknU40_t8zeqp7CoYnnZRQtm79qHxMGXyyiSqGPISUkzEK6O8HPNh0dVWvyI-SNzAQyJQg8J3RC26bgo7SpVDt8oGGMiKsBnssuXO60MqEs_vt3Q4-xdXIJQOj0YX4ICEeHJ3nq1pigWRLg";
+    String authV2 = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6IlF6bEVPVFE1TTBOR01EazROakV4T0VKR01qYzJNalZGT0RoRVFrRTFOVUkyTmtFMFJUUXlSZyJ9.eyJpc3MiOiJodHRwczovL25kbGEtdGVzdC5ldS5hdXRoMC5jb20vIiwic3ViIjoiMjRaYmkyYjJycGdVVnZQNzFEV3ZTNUloVVk0ZlpGSjNAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiaWF0IjoxNTQ0NTIwMjg3LCJleHAiOjE1NDQ1MjIwODcsImF6cCI6IjI0WmJpMmIycnBnVVZ2UDcxRFd2UzVJaFVZNGZaRkozIiwic2NvcGUiOiJ0YXhvbm9teTp3cml0ZSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.Yon-Jm1RAe5jn0bS8NTQ2bIZWNAO-M3JN_G8PvxbuMtKLqOZ7SydAx9cgDysKg95HRj8tCVpj1fDttKSIm59Ww-400gmDTTlQPqdzlNWsXT7wgAllTboXEigGAmjj1tNKYFQxTdIa9azdiqUPT-e7ao5JOdM3_uYFiINC_MoxfFaezGSWeja4TkEakj8MyxGraKa6DhXrlLd1TfZtH6bv6mxEyAy_YmYZQ1vQ8iZKdGM1AHp703yoqITutrfzdZOx-yxNUcmPJwqzcm3cXd0RA-qwJ5NfsuZrS52NtrDqRaxGdIuai9W04nM5ZEfvkvpFGe8gU6fZ8is0ThiS39luQ";
+    String authV2WithAdmin = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IlF6bEVPVFE1TTBOR01EazROakV4T0VKR01qYzJNalZGT0RoRVFrRTFOVUkyTmtFMFJUUXlSZyJ9.eyJpc3MiOiJodHRwczovL25kbGEtdGVzdC5ldS5hdXRoMC5jb20vIiwic3ViIjoiZnNleE9DZkpGR09LdXkxQzJlNzFPc3ZRd3EwTldLQUtAY2xpZW50cyIsImF1ZCI6Im5kbGFfc3lzdGVtIiwiaWF0IjoxNjM2NTQ0MDIxLCJleHAiOjE2MzY1NDc2MjEsImF6cCI6ImZzZXhPQ2ZKRkdPS3V5MUMyZTcxT3N2UXdxME5XS0FLIiwic2NvcGUiOiJhcnRpY2xlczpwdWJsaXNoIGFydGljbGVzOndyaXRlIGF1ZGlvOndyaXRlIGNvbmNlcHQ6d3JpdGUgZHJhZnRzOmFkbWluIGRyYWZ0czpwdWJsaXNoIGRyYWZ0czp3cml0ZSBpbWFnZXM6d3JpdGUgbGVhcm5pbmdwYXRoOmFkbWluIGxlYXJuaW5ncGF0aDpwdWJsaXNoIGxlYXJuaW5ncGF0aDp3cml0ZSB0YXhvbm9teTphZG1pbiB0YXhvbm9teTp3cml0ZSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyJ9.KFJ1HF1b3otp2WIKVDh9It_OwnWY6WkibcgxWJkyFfHFZERtgxRUCHVUKPxoQds4ooYjIv9mwx0jZNAjA0v2J6d8FB5sfKoEPTt4zO7TTSBkehytKgWawqtT_bBWoxYralw__hSWE2-q5UMbMN_i-Z09_8M9SojaWVF1cuTdLf4XBa24cl4oj4IfIQdGKaqI1qdXS8fwn0EoID419a3u-w_sg_m28R2lqdot-6gePeZZJE6dpTeiJC7rGDL9YDJ4JxnI4ZmAXvYMeResJJBFo_Ur5aqeXHZqr34y1LdywIiIWp7I0CMPk6T9HD_GxCLVmFk87zokxUT4Shx_Pa8y5A";
 
     @Test
-    public void no_taxonomy_in_jwt_token_gives_read_permission() {
-        DecodedJWT jwt = JWT.decode(authorizationHeader.substring(6).trim());
+    public void no_taxonomy_in_old_token_gives_read_permission() {
+        DecodedJWT jwt = JWT.decode(auth.substring(6).trim());
 
         JWTAuthentication token = new JWTAuthentication(jwt);
         assertTrue(token.isAuthenticated());
@@ -34,8 +35,8 @@ public class JWTTokenTest {
     }
 
     @Test
-    public void new_jwt_token_gives_read_write_permission() {
-        DecodedJWT jwt = JWT.decode(authorizationHeaderv2.substring(6).trim());
+    public void jwt_token_gives_read_write_permissions() {
+        DecodedJWT jwt = JWT.decode(authV2.substring(6).trim());
         JWTAuthentication token = new JWTAuthentication(jwt);
         assertTrue(token.isAuthenticated());
         assertEquals(2, token.getAuthorities().size());
@@ -44,8 +45,19 @@ public class JWTTokenTest {
     }
 
     @Test
-    public void write_gives_write_permission() {
-        JWT.decode(authorizationHeader.substring(6).trim());
+    public void jwt_token_gives_read_write_admin_permissions() {
+        DecodedJWT jwt = JWT.decode(authV2WithAdmin.substring(6).trim());
+        JWTAuthentication token = new JWTAuthentication(jwt);
+        assertTrue(token.isAuthenticated());
+        assertEquals(3, token.getAuthorities().size());
+        assertAnyTrue(token.getAuthorities(), au -> "READONLY".equals(au.getAuthority()));
+        assertAnyTrue(token.getAuthorities(), au -> "TAXONOMY_ADMIN".equals(au.getAuthority()));
+        assertAnyTrue(token.getAuthorities(), au -> "TAXONOMY_WRITE".equals(au.getAuthority()));
+    }
+
+    @Test
+    public void old_token_gives_write_permission() {
+        JWT.decode(auth.substring(6).trim());
 
         final DecodedJWT mockDecodedJWT = Mockito.mock(DecodedJWT.class);
         Claim claim = Mockito.mock(Claim.class);
@@ -59,9 +71,6 @@ public class JWTTokenTest {
 
     @Test
     public void no_scope_gives_readonly() {
-
-        JWT.decode(authorizationHeader.substring(6).trim());
-
         final DecodedJWT mockDecodedJWT = Mockito.mock(DecodedJWT.class);
         Claim claim = Mockito.mock(Claim.class);
         when(claim.asString()).thenReturn(null);

--- a/src/test/java/no/ndla/taxonomy/TestUtils.java
+++ b/src/test/java/no/ndla/taxonomy/TestUtils.java
@@ -92,8 +92,12 @@ public class TestUtils {
     public MockHttpServletResponse updateResource(String path, Object command, ResultMatcher resultMatcher)
             throws Exception {
         entityManager.flush();
-        return mockMvc.perform(put(path).contentType(APPLICATION_JSON_UTF8).content(json(command)))
-                .andExpect(resultMatcher).andReturn().getResponse();
+        if (command == null)
+            return mockMvc.perform(put(path).contentType(APPLICATION_JSON_UTF8)).andExpect(resultMatcher).andReturn()
+                    .getResponse();
+        else
+            return mockMvc.perform(put(path).contentType(APPLICATION_JSON_UTF8).content(json(command)))
+                    .andExpect(resultMatcher).andReturn().getResponse();
     }
 
     public static URI getId(MockHttpServletResponse response) {

--- a/src/test/java/no/ndla/taxonomy/domain/VersionTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/VersionTest.java
@@ -1,0 +1,36 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class VersionTest {
+    private Version version;
+
+    @BeforeEach
+    public void setUp() {
+        version = new Version();
+    }
+
+    @Test
+    public void has_public_id() {
+        assertTrue(version.getPublicId() != null);
+        assertTrue(version.getPublicId().toString().startsWith("urn:version:"));
+    }
+
+    @Test
+    public void version_type_can_be_changed() {
+        assertEquals(version.getVersionType(), VersionType.BETA);
+        version.setVersionType(VersionType.PUBLISHED);
+        assertEquals(version.getVersionType(), VersionType.PUBLISHED);
+    }
+}

--- a/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
@@ -42,6 +42,9 @@ public abstract class RestTest {
     EntityManager entityManager;
 
     @Autowired
+    VersionRepository versionRepository;
+
+    @Autowired
     ResourceResourceTypeRepository resourceResourceTypeRepository;
 
     @Autowired

--- a/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
@@ -7,10 +7,8 @@
 
 package no.ndla.taxonomy.rest.v1;
 
-import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.Version;
 import no.ndla.taxonomy.domain.VersionType;
-import no.ndla.taxonomy.rest.v1.commands.SubjectCommand;
 import no.ndla.taxonomy.rest.v1.commands.VersionCommand;
 import no.ndla.taxonomy.service.dtos.VersionDTO;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,8 +17,10 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.net.URI;
 
-import static no.ndla.taxonomy.TestUtils.*;
+import static no.ndla.taxonomy.TestUtils.assertAllTrue;
+import static no.ndla.taxonomy.TestUtils.getId;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class VersionsTest extends RestTest {
 
@@ -49,7 +49,7 @@ public class VersionsTest extends RestTest {
         VersionDTO version = testUtils.getObject(VersionDTO.class, response);
         assertEquals(versionId, version.getId());
 
-        assertNotNull(version.getCreated());
+        assertNotNull(version.getHash());
         assertNull(version.getPublished());
         assertNull(version.getArchived());
     }
@@ -76,6 +76,7 @@ public class VersionsTest extends RestTest {
         final var createVersionCommand = new VersionCommand() {
             {
                 id = URI.create("urn:version:1");
+                name = "Beta";
             }
         };
 
@@ -85,25 +86,70 @@ public class VersionsTest extends RestTest {
         Version version = versionRepository.getByPublicId(id);
         assertEquals(createVersionCommand.id, version.getPublicId());
         assertEquals(VersionType.BETA, version.getVersionType());
+        assertEquals("Beta", version.getName());
     }
 
     @Test
     public void can_update_version() throws Exception {
         Version version = builder.version();// BETA
-        URI newUri =  URI.create("urn:version:1");
+        URI newUri = URI.create("urn:version:1");
         final var updateVersionCommand = new VersionCommand() {
             {
                 id = newUri;
+                name = "New name";
             }
         };
 
-        MockHttpServletResponse response = testUtils.updateResource("/v1/versions/" + version.getPublicId(), updateVersionCommand);
+        MockHttpServletResponse response = testUtils.updateResource("/v1/versions/" + version.getPublicId(),
+                updateVersionCommand);
 
         Version updated = versionRepository.getByPublicId(newUri);
         assertEquals(updateVersionCommand.id, updated.getPublicId());
         assertEquals(VersionType.BETA, updated.getVersionType());
+        assertEquals("New name", updated.getName());
+        assertEquals(version.getHash(), updated.getHash()); // Not changed during update
     }
 
+    @Test
+    public void can_publish_version() throws Exception {
+        Version version = builder.version();// BETA
+        MockHttpServletResponse response = testUtils
+                .updateResource("/v1/versions/" + version.getPublicId() + "/publish", null);
 
+        Version updated = versionRepository.getByPublicId(version.getPublicId());
+        assertEquals(VersionType.PUBLISHED, updated.getVersionType());
+        assertNotNull(updated.getPublished());
+    }
+
+    @Test
+    public void cannot_publish_published_or_archived_version() throws Exception {
+        Version version = builder.version(v -> v.type(VersionType.PUBLISHED));
+        MockHttpServletResponse response = testUtils.updateResource(
+                "/v1/versions/" + version.getPublicId() + "/publish", null, status().is4xxClientError());
+        assertEquals(400, response.getStatus());
+        assertEquals("{\"error\":\"Version has wrong type\"}", response.getContentAsString());
+
+        Version version2 = builder.version(v -> v.type(VersionType.ARCHIVED));
+        MockHttpServletResponse response2 = testUtils.updateResource(
+                "/v1/versions/" + version2.getPublicId() + "/publish", null, status().is4xxClientError());
+        assertEquals(400, response2.getStatus());
+        assertEquals("{\"error\":\"Version has wrong type\"}", response2.getContentAsString());
+    }
+
+    @Test
+    public void publishing_version_unpublishes_current() throws Exception {
+        Version published = builder.version(v -> v.type(VersionType.PUBLISHED));
+        Version beta = builder.version();
+        MockHttpServletResponse response = testUtils.updateResource("/v1/versions/" + beta.getPublicId() + "/publish",
+                null);
+
+        Version updated = versionRepository.getByPublicId(beta.getPublicId());
+        assertEquals(VersionType.PUBLISHED, updated.getVersionType());
+        assertNotNull(updated.getPublished());
+
+        Version unpublished = versionRepository.getByPublicId(published.getPublicId());
+        assertEquals(VersionType.ARCHIVED, unpublished.getVersionType());
+        assertNotNull(unpublished.getArchived());
+    }
 
 }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
@@ -1,0 +1,109 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.rest.v1;
+
+import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.Version;
+import no.ndla.taxonomy.domain.VersionType;
+import no.ndla.taxonomy.rest.v1.commands.SubjectCommand;
+import no.ndla.taxonomy.rest.v1.commands.VersionCommand;
+import no.ndla.taxonomy.service.dtos.VersionDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.net.URI;
+
+import static no.ndla.taxonomy.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VersionsTest extends RestTest {
+
+    @BeforeEach
+    void cleanDatabase() {
+        versionRepository.deleteAllAndFlush();
+    }
+
+    @Test
+    public void can_get_all_versions() throws Exception {
+        builder.version();
+        builder.version();
+
+        MockHttpServletResponse response = testUtils.getResource("/v1/versions");
+        VersionDTO[] versions = testUtils.getObject(VersionDTO[].class, response);
+        assertEquals(2, versions.length);
+
+    }
+
+    @Test
+    public void can_get_specified_version() throws Exception {
+        URI versionId = URI.create("urn:version:1");
+        builder.version(v -> v.publicId(versionId));
+
+        MockHttpServletResponse response = testUtils.getResource("/v1/versions/" + versionId);
+        VersionDTO version = testUtils.getObject(VersionDTO.class, response);
+        assertEquals(versionId, version.getId());
+
+        assertNotNull(version.getCreated());
+        assertNull(version.getPublished());
+        assertNull(version.getArchived());
+    }
+
+    @Test
+    public void can_get_versions_of_type() throws Exception {
+        Version version = builder.version();// BETA
+        MockHttpServletResponse response = testUtils.getResource("/v1/versions/?type=BETA");
+        VersionDTO[] versions = testUtils.getObject(VersionDTO[].class, response);
+        assertEquals(1, versions.length);
+        assertAllTrue(versions, v -> v.getVersionType() == VersionType.BETA);
+        assertAllTrue(versions, v -> v.getId().equals(version.getPublicId()));
+
+        Version version2 = builder.version(v -> v.type(VersionType.PUBLISHED));
+        MockHttpServletResponse response2 = testUtils.getResource("/v1/versions/?type=PUBLISHED");
+        VersionDTO[] versions2 = testUtils.getObject(VersionDTO[].class, response2);
+        assertEquals(1, versions2.length);
+        assertAllTrue(versions2, v -> v.getVersionType() == VersionType.PUBLISHED);
+        assertAllTrue(versions2, v -> v.getId().equals(version2.getPublicId()));
+    }
+
+    @Test
+    public void can_create_version() throws Exception {
+        final var createVersionCommand = new VersionCommand() {
+            {
+                id = URI.create("urn:version:1");
+            }
+        };
+
+        MockHttpServletResponse response = testUtils.createResource("/v1/versions", createVersionCommand);
+        URI id = getId(response);
+
+        Version version = versionRepository.getByPublicId(id);
+        assertEquals(createVersionCommand.id, version.getPublicId());
+        assertEquals(VersionType.BETA, version.getVersionType());
+    }
+
+    @Test
+    public void can_update_version() throws Exception {
+        Version version = builder.version();// BETA
+        URI newUri =  URI.create("urn:version:1");
+        final var updateVersionCommand = new VersionCommand() {
+            {
+                id = newUri;
+            }
+        };
+
+        MockHttpServletResponse response = testUtils.updateResource("/v1/versions/" + version.getPublicId(), updateVersionCommand);
+
+        Version updated = versionRepository.getByPublicId(newUri);
+        assertEquals(updateVersionCommand.id, updated.getPublicId());
+        assertEquals(VersionType.BETA, updated.getVersionType());
+    }
+
+
+
+}

--- a/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/VersionsTest.java
@@ -152,4 +152,21 @@ public class VersionsTest extends RestTest {
         assertNotNull(unpublished.getArchived());
     }
 
+    @Test
+    public void generate_files_only_works_for_betas() throws Exception {
+        Version published = builder.version(v -> v.type(VersionType.PUBLISHED));
+        MockHttpServletResponse response = testUtils.updateResource(
+                "/v1/versions/" + published.getPublicId() + "/generate", null, status().is4xxClientError());
+        assertEquals(400, response.getStatus());
+        assertEquals("{\"error\":\"Cannot update production version\"}", response.getContentAsString());
+    }
+
+    @Test
+    public void generate_files_works_for_betas() throws Exception {
+        Version beta = builder.version();
+        MockHttpServletResponse response = testUtils.updateResource("/v1/versions/" + beta.getPublicId() + "/generate",
+                null);
+        assertEquals(204, response.getStatus());
+    }
+
 }

--- a/src/test/java/no/ndla/taxonomy/util/HashUtilTest.java
+++ b/src/test/java/no/ndla/taxonomy/util/HashUtilTest.java
@@ -1,0 +1,37 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class HashUtilTest {
+
+    @Test
+    public void get_different_length_hashes() {
+        String shortHash = HashUtil.shortHash("original");
+        String mediumHash = HashUtil.mediumHash("original");
+        String longHash = HashUtil.longHash("original");
+        String fullHash = HashUtil.fullHash("original");
+
+        assertEquals(4, shortHash.length());
+        assertEquals(8, mediumHash.length());
+        assertEquals(16, longHash.length());
+        assertTrue(fullHash.length() > 16);
+    }
+
+    @Test
+    public void same_string_gives_same_hashes() {
+        String hash1 = HashUtil.mediumHash("original");
+        String hash2 = HashUtil.mediumHash("original");
+        String hash3 = HashUtil.longHash("original");
+        assertEquals(hash1, hash2);
+        assertTrue(hash3.startsWith(hash2));
+    }
+}


### PR DESCRIPTION
Fixes NDLANO/Issues#2854
Depends on NDLANO/deploy/pull/368

Legger til tabell for versjoner, samt endepunkt for å lagre, oppdatere og publisere. I tillegg til generering av filer for endepunktkall. Dette tar endå veldig lang tid. Det kan nok gjøres bedre ved å innføre meir asynkronitet. No er det masse interne kall og skriving til s3.