### PR TITLE
Håndterer auth exceptions på samme måte som andre exceptions.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/ControllerExceptionHandler.java
+++ b/src/main/java/no/ndla/taxonomy/rest/ControllerExceptionHandler.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.rest;
 
+import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import no.ndla.taxonomy.service.exceptions.DuplicateConnectionException;
 import no.ndla.taxonomy.service.exceptions.InvalidArgumentServiceException;
@@ -16,6 +17,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
@@ -38,6 +40,11 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
         return headers;
     }
 
+    @ExceptionHandler({ JWTVerificationException.class, AccessDeniedException.class })
+    protected ResponseEntity<String> handleAuthenticationExceptions(RuntimeException exception) {
+        return new ResponseEntity<>(createErrorBody(exception), createHeaders(), HttpStatus.UNAUTHORIZED);
+    }
+
     @ExceptionHandler(ServiceUnavailableException.class)
     protected ResponseEntity<String> handleServiceUnavailableException(RuntimeException exception) {
         return new ResponseEntity<>(createErrorBody(exception), createHeaders(), HttpStatus.SERVICE_UNAVAILABLE);
@@ -57,4 +64,5 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<String> handleInvalidArgumentExceptions(RuntimeException exception) {
         return new ResponseEntity<>(createErrorBody(exception), createHeaders(), HttpStatus.BAD_REQUEST);
     }
+
 }

--- a/src/main/java/no/ndla/taxonomy/security/AuthFilter.java
+++ b/src/main/java/no/ndla/taxonomy/security/AuthFilter.java
@@ -23,11 +23,14 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.AuthorizationServiceException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -65,17 +68,9 @@ public class AuthFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
-            throws IOException {
-        try {
-            parseWebToken((HttpServletRequest) servletRequest);
-            filterChain.doFilter(servletRequest, servletResponse);
-        } catch (TokenExpiredException ex) {
-            LOGGER.error("Remote host: " + servletRequest.getRemoteAddr() + " " + ex.getMessage());
-            ((HttpServletResponse) servletResponse).sendError(HttpServletResponse.SC_UNAUTHORIZED, ex.getMessage());
-        } catch (Exception ex) {
-            LOGGER.error("Remote host: " + servletRequest.getRemoteAddr() + " " + ex.getMessage());
-            ((HttpServletResponse) servletResponse).sendError(HttpServletResponse.SC_BAD_REQUEST, ex.getMessage());
-        }
+            throws IOException, ServletException {
+        parseWebToken((HttpServletRequest) servletRequest);
+        filterChain.doFilter(servletRequest, servletResponse);
     }
 
     private void parseWebToken(HttpServletRequest request) {


### PR DESCRIPTION
Fjerner unødvending dobbelhåndtering av exceptions. Gammel løsning returnerer 400 og ikkje 403.

Test:
Kan testes lokalt ved å deploye i docker. Alle kall uten token skal gi korrekt statuskode og melding. I test no får du kun 400 om du kaller PUT eller PATCH uten token,