### PR TITLE
Adds `/search` endpoint for resources, nodes, topics and subjects

### DIFF
--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -8,7 +8,6 @@
 package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Node;
-import no.ndla.taxonomy.domain.NodeType;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;

--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
@@ -8,6 +8,8 @@
 package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
@@ -29,6 +31,8 @@ public interface ResourceRepository extends TaxonomyRepository<Resource> {
 
     @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths WHERE r.publicId = :publicId")
     Optional<Resource> findFirstByPublicIdIncludingCachedUrls(URI publicId);
+
+    Page<Resource> searchAllByNameContainingIgnoreCase(String name, Pageable pageable);
 
     @Query("SELECT distinct r FROM Resource r LEFT JOIN FETCH r.cachedPaths LEFT JOIN FETCH r.metadata m"
             + " LEFT JOIN FETCH m.grepCodes LEFT JOIN m.customFieldValues cfv LEFT JOIN cfv.customField"

--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
@@ -8,8 +8,6 @@
 package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Resource;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
@@ -31,8 +29,6 @@ public interface ResourceRepository extends TaxonomyRepository<Resource> {
 
     @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths WHERE r.publicId = :publicId")
     Optional<Resource> findFirstByPublicIdIncludingCachedUrls(URI publicId);
-
-    Page<Resource> searchAllByNameContainingIgnoreCase(String name, Pageable pageable);
 
     @Query("SELECT distinct r FROM Resource r LEFT JOIN FETCH r.cachedPaths LEFT JOIN FETCH r.metadata m"
             + " LEFT JOIN FETCH m.grepCodes LEFT JOIN m.customFieldValues cfv LEFT JOIN cfv.customField"

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -68,6 +68,21 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
         return nodeService.getNodes(language, nodeType, contentUri, isRoot, metadataFilters);
     }
 
+    @GetMapping("/search")
+    @ApiOperation(value = "Search all nodes")
+    @Transactional(readOnly = true)
+    public SearchResultDTO<NodeDTO> search(
+            @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", defaultValue = "") Optional<String> language,
+            @ApiParam(value = "How many results to return per page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @ApiParam(value = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
+            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query,
+            @ApiParam(value = "Ids to fetch for query") @RequestParam(value = "ids") Optional<List<String>> ids,
+            @ApiParam(value = "Filter by nodeType") @RequestParam(value = "nodeType") Optional<NodeType> nodeType
+
+    ) {
+        return nodeService.searchByNodeType(query, ids, language, pageSize, page, nodeType);
+    }
+
     @GetMapping("/{id}")
     @ApiOperation("Gets a single node")
     @Transactional

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -68,12 +68,13 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
     @Transactional(readOnly = true)
     public SearchResultDTO<ResourceDTO> search(
             @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", defaultValue = "") Optional<String> language,
-            @ApiParam(value = "How many results to return pr page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @ApiParam(value = "How many results to return per page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
             @ApiParam(value = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
-            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query
+            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query,
+            @ApiParam(value = "Ids to fetch for query") @RequestParam(value = "ids") Optional<List<String>> ids
 
     ) {
-        return resourceService.searchResources(query, language, pageSize, page);
+        return resourceService.search(query, ids, language, pageSize, page);
     }
 
     @GetMapping("{id}")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -17,6 +17,7 @@ import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.ResourceDTO;
 import no.ndla.taxonomy.service.dtos.ResourceTypeWithConnectionDTO;
 import no.ndla.taxonomy.service.dtos.ResourceWithParentsDTO;
+import no.ndla.taxonomy.service.dtos.SearchResultDTO;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -60,6 +61,19 @@ public class Resources extends CrudControllerWithMetadata<Resource> {
             @ApiParam(value = "Filter by visible") @RequestParam(value = "isVisible") Optional<Boolean> isVisible) {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         return resourceService.getResources(language, contentUri, metadataFilters);
+    }
+
+    @GetMapping("/search")
+    @ApiOperation(value = "Search all resources")
+    @Transactional(readOnly = true)
+    public SearchResultDTO<ResourceDTO> search(
+            @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", defaultValue = "") Optional<String> language,
+            @ApiParam(value = "How many results to return pr page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @ApiParam(value = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
+            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query
+
+    ) {
+        return resourceService.searchResources(query, language, pageSize, page);
     }
 
     @GetMapping("{id}")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -65,6 +65,19 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 metadataFilters);
     }
 
+    @GetMapping("/search")
+    @ApiOperation(value = "Search all subjects")
+    public SearchResultDTO<NodeDTO> search(
+            @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", defaultValue = "") Optional<String> language,
+            @ApiParam(value = "How many results to return per page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @ApiParam(value = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
+            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query,
+            @ApiParam(value = "Ids to fetch for query") @RequestParam(value = "ids") Optional<List<String>> ids
+
+    ) {
+        return nodeService.searchByNodeType(query, ids, language, pageSize, page, Optional.of(NodeType.SUBJECT));
+    }
+
     @GetMapping("/{id}")
     @ApiOperation(value = "Gets a single subject", notes = "Default language will be returned if desired language not found or if parameter is omitted.")
     public EntityWithPathDTO get(@PathVariable("id") URI id,

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -56,6 +56,19 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 metadataFilters);
     }
 
+    @GetMapping("/search")
+    @ApiOperation(value = "Search all topics")
+    public SearchResultDTO<NodeDTO> search(
+            @ApiParam(value = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", defaultValue = "") Optional<String> language,
+            @ApiParam(value = "How many results to return per page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
+            @ApiParam(value = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
+            @ApiParam(value = "Query to search names") @RequestParam(value = "query") Optional<String> query,
+            @ApiParam(value = "Ids to fetch for query") @RequestParam(value = "ids") Optional<List<String>> ids
+
+    ) {
+        return nodeService.searchByNodeType(query, ids, language, pageSize, page, Optional.of(NodeType.TOPIC));
+    }
+
     @GetMapping("/{id}")
     @ApiOperation("Gets a single topic")
     @Transactional

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -19,9 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.criteria.Join;
 import java.net.URI;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -29,7 +27,7 @@ import static org.springframework.data.jpa.domain.Specification.where;
 
 @Transactional(readOnly = true)
 @Service
-public class NodeService {
+public class NodeService implements SearchService<NodeDTO, Node, NodeRepository> {
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;
     private final EntityConnectionService connectionService;
@@ -141,5 +139,20 @@ public class NodeService {
                 .collect(Collectors.toUnmodifiableList());
 
         return topicTreeSorter.sortList(wrappedList);
+    }
+
+    @Override
+    public NodeRepository getRepository() {
+        return nodeRepository;
+    }
+
+    @Override
+    public NodeDTO createDTO(Node node, String languageCode) {
+        return new NodeDTO(node, languageCode);
+    }
+
+    public SearchResultDTO<NodeDTO> searchByNodeType(Optional<String> query, Optional<List<String>> ids, Optional<String> language, int pageSize, int page, Optional<NodeType> nodeType) {
+        Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasNodeType(nt))));
+        return SearchService.super.search(query, ids, language, pageSize, page, nodeSpecLambda);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -151,7 +151,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
         return new NodeDTO(node, languageCode);
     }
 
-    public SearchResultDTO<NodeDTO> searchByNodeType(Optional<String> query, Optional<List<String>> ids, Optional<String> language, int pageSize, int page, Optional<NodeType> nodeType) {
+    public SearchResultDTO<NodeDTO> searchByNodeType(Optional<String> query, Optional<List<String>> ids,
+            Optional<String> language, int pageSize, int page, Optional<NodeType> nodeType) {
         Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasNodeType(nt))));
         return SearchService.super.search(query, ids, language, pageSize, page, nodeSpecLambda);
     }

--- a/src/main/java/no/ndla/taxonomy/service/ResourceService.java
+++ b/src/main/java/no/ndla/taxonomy/service/ResourceService.java
@@ -7,6 +7,8 @@
 
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.domain.Resource;
+import no.ndla.taxonomy.repositories.ResourceRepository;
 import no.ndla.taxonomy.service.dtos.*;
 
 import java.net.URI;
@@ -14,7 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-public interface ResourceService {
+public interface ResourceService extends SearchService<ResourceDTO, Resource, ResourceRepository> {
     void delete(URI id);
 
     List<ResourceWithNodeConnectionDTO> getResourcesByNodeId(URI nodePublicId, Set<URI> resourceTypeIds,
@@ -26,7 +28,4 @@ public interface ResourceService {
 
     List<ResourceDTO> getResources(Optional<String> language, Optional<URI> contentUri,
             MetadataFilters metadataFilters);
-
-    SearchResultDTO<ResourceDTO> searchResources(Optional<String> query, Optional<String> language, int pageSize,
-            int page);
 }

--- a/src/main/java/no/ndla/taxonomy/service/ResourceService.java
+++ b/src/main/java/no/ndla/taxonomy/service/ResourceService.java
@@ -26,4 +26,7 @@ public interface ResourceService {
 
     List<ResourceDTO> getResources(Optional<String> language, Optional<URI> contentUri,
             MetadataFilters metadataFilters);
+
+    SearchResultDTO<ResourceDTO> searchResources(Optional<String> query, Optional<String> language, int pageSize,
+            int page);
 }

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -1,0 +1,79 @@
+package no.ndla.taxonomy.service;
+
+import no.ndla.taxonomy.repositories.TaxonomyRepository;
+import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.springframework.data.jpa.domain.Specification.where;
+
+interface ExtraSpecification<T> {
+    Specification<T> applySpecification(Specification<T> spec);
+}
+
+public interface SearchService<DTO, DOMAIN, REPO extends TaxonomyRepository<DOMAIN>> {
+    REPO getRepository();
+    DTO createDTO(DOMAIN domain, String languageCode);
+
+    private Specification<DOMAIN> base() {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.isNotNull(root.get("id"));
+    }
+
+    private Specification<DOMAIN> withNameLike(String name) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.like(criteriaBuilder.lower(root.get("name")),
+                "%" + name.toLowerCase() + "%");
+    }
+
+    private Specification<DOMAIN> withPublicIdsIn(List<URI> ids) {
+        return (root, query, criteriaBuilder) -> root.get("publicId").in(ids);
+    }
+
+
+    default SearchResultDTO<DTO> search(Optional<String> query, Optional<List<String>> ids, Optional<String> language,
+                                        int pageSize, int page) {
+        return search(query, ids, language, pageSize, page, Optional.empty());
+    }
+
+    default SearchResultDTO<DTO> search(Optional<String> query, Optional<List<String>> ids, Optional<String> language,
+            int pageSize, int page, Optional<ExtraSpecification<DOMAIN>> applySpecLambda) {
+        if (page < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var pageRequest = PageRequest.of(page - 1, pageSize);
+        Specification<DOMAIN> spec = where(base());
+
+        if (query.isPresent()) {
+            spec = spec.and(withNameLike(query.get()));
+        }
+
+        if (ids.isPresent()) {
+            List<URI> urisToPass = ids.get().stream().flatMap(id -> {
+                try {
+                    return Optional.of(new URI(id)).stream();
+                } catch (URISyntaxException ignored) {
+                    /* ignore invalid urls sent by user */ }
+                return Optional.<URI> empty().stream();
+            }).collect(Collectors.toList());
+
+            if (!urisToPass.isEmpty())
+                spec = spec.and(withPublicIdsIn(urisToPass));
+        }
+
+        if(applySpecLambda.isPresent()){
+            spec = applySpecLambda.get().applySpecification(spec);
+        }
+
+        var fetched = getRepository().findAll(spec, pageRequest);
+
+        var languageCode = language.orElse("");
+        var dtos = fetched.stream().map(r -> createDTO(r, languageCode)).collect(Collectors.toList());
+
+        return new SearchResultDTO<>(fetched.getTotalElements(), page, pageSize, dtos);
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -19,6 +19,7 @@ interface ExtraSpecification<T> {
 
 public interface SearchService<DTO, DOMAIN, REPO extends TaxonomyRepository<DOMAIN>> {
     REPO getRepository();
+
     DTO createDTO(DOMAIN domain, String languageCode);
 
     private Specification<DOMAIN> base() {
@@ -34,9 +35,8 @@ public interface SearchService<DTO, DOMAIN, REPO extends TaxonomyRepository<DOMA
         return (root, query, criteriaBuilder) -> root.get("publicId").in(ids);
     }
 
-
     default SearchResultDTO<DTO> search(Optional<String> query, Optional<List<String>> ids, Optional<String> language,
-                                        int pageSize, int page) {
+            int pageSize, int page) {
         return search(query, ids, language, pageSize, page, Optional.empty());
     }
 
@@ -65,7 +65,7 @@ public interface SearchService<DTO, DOMAIN, REPO extends TaxonomyRepository<DOMA
                 spec = spec.and(withPublicIdsIn(urisToPass));
         }
 
-        if(applySpecLambda.isPresent()){
+        if (applySpecLambda.isPresent()) {
             spec = applySpecLambda.get().applySpecification(spec);
         }
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
@@ -1,0 +1,33 @@
+package no.ndla.taxonomy.service.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+
+import java.util.List;
+
+@ApiModel("SearchResult")
+public class SearchResultDTO<T> {
+    @JsonProperty
+    @ApiModelProperty(example = "Total search result count, useful for fetching multiple pages")
+    private long totalCount;
+
+    @JsonProperty
+    @ApiModelProperty(example = "The page number")
+    private int page;
+
+    @JsonProperty
+    @ApiModelProperty(example = "The page size")
+    private int pageSize;
+
+    @JsonProperty
+    @ApiModelProperty(example = "List of search results")
+    private List<T> results;
+
+    public SearchResultDTO(long totalCount, int pageNumber, int pageSize, List<T> results) {
+        this.totalCount = totalCount;
+        this.page = pageNumber;
+        this.pageSize = pageSize;
+        this.results = results;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
@@ -31,8 +31,19 @@ public class SearchResultDTO<T> {
         this.results = results;
     }
 
-    public int getPage() { return page; }
-    public int getPageSize() { return pageSize; }
-    public List<T> getResults() { return results; }
-    public long getTotalCount() { return totalCount; }
+    public int getPage() {
+        return page;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public List<T> getResults() {
+        return results;
+    }
+
+    public long getTotalCount() {
+        return totalCount;
+    }
 }

--- a/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/SearchResultDTO.java
@@ -30,4 +30,9 @@ public class SearchResultDTO<T> {
         this.pageSize = pageSize;
         this.results = results;
     }
+
+    public int getPage() { return page; }
+    public int getPageSize() { return pageSize; }
+    public List<T> getResults() { return results; }
+    public long getTotalCount() { return totalCount; }
 }


### PR DESCRIPTION
Legger til `/search` endepunkter.
Tenker vi at det er lurt at jeg legger de til på "koblings" endepunktene også? (`/subject-topics/`, `/topic-subtopics` etc?)

I første omgang så gjør jeg bare `LIKE` og `x.publicId IN` for å hente basert på `?query` og `?ids`.
Om vi skal utvide søket til å bli mer omfattende (i likhet med andre apier) så stemmer jeg for å kikke på elasticsearch her også, men i første omgang så tror jeg dette kommer til å fungere fint (I alle fall mye finenre enn å gjøre en request for å fetche alle topics og filtrere de i frontend :smile:).

Kan testes ved å feks gå til `v1/resources/search` eller `v1/nodes/search`