### PR TITLE
Adds `translations` and `supportedLanguages` to `EntityWithPathChildDTO`

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
@@ -14,12 +14,15 @@ import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeConnection;
 import no.ndla.taxonomy.domain.Relevance;
 import no.ndla.taxonomy.domain.Translation;
+import no.ndla.taxonomy.rest.v1.NodeTranslations;
+import no.ndla.taxonomy.rest.v1.NodeTranslations.TranslationDTO;
 import no.ndla.taxonomy.service.TreeSorter;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -53,6 +56,12 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
     @ApiModelProperty(value = "Relevance id", example = "urn:relevance:core")
     public URI relevanceId;
 
+    @ApiModelProperty(value = "All translations of this resource")
+    public Set<NodeTranslations.TranslationDTO> translations;
+
+    @ApiModelProperty(value = "List of language codes supported by translations")
+    public Set<String> supportedLanguages;
+
     @JsonIgnore
     public List<EntityWithPathChildDTO> children = new ArrayList<>();
 
@@ -70,6 +79,10 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
             this.path = child.getPathByContext(node).orElse("");
             this.paths = child.getAllPaths();
             this.metadata = new MetadataDto(child.getMetadata());
+
+            var translations = child.getTranslations();
+            this.translations = translations.stream().map(TranslationDTO::new).collect(Collectors.toSet());
+            this.supportedLanguages = this.translations.stream().map(t -> t.language).collect(Collectors.toSet());
         });
 
         nodeConnection.getParent().ifPresent(parent -> this.parent = parent.getPublicId());


### PR DESCRIPTION
Glemte disse sist gang :)
(Ganske sikker på at det ble <11 minutter @N4G1 )

Kan testes ved å sjekke at topics som returneres fra `v1/subject/<subjectId>/topics` har `translations` og `supportedLanguages`
Feks http://localhost:5000/v1/subjects/urn:subject:1:0d67724e-d9fa-4365-9839-4cc91c012855/topics/ om du har test-data