### PR TITLE
Fix cascading ranking

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/RankableConnectionUpdater.java
+++ b/src/main/java/no/ndla/taxonomy/service/RankableConnectionUpdater.java
@@ -41,9 +41,9 @@ public class RankableConnectionUpdater {
         for (int i = startFromIndex; i < existingConnections.size(); i++) {
             EntityWithPathConnection currentItem = existingConnections.get(i);
             int currentRank = currentItem.getRank();
-            if (currentRank == lastUpdatedConnectionRank) {
-                currentItem.setRank(currentRank + 1);
-                lastUpdatedConnectionRank = currentRank + 1;
+            if (currentRank <= lastUpdatedConnectionRank) {
+                currentItem.setRank(lastUpdatedConnectionRank + 1);
+                lastUpdatedConnectionRank = lastUpdatedConnectionRank + 1;
             } else
                 return;
         }

--- a/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
@@ -48,7 +48,7 @@ public class RankableConnectionUpdaterTest {
         RankableConnectionUpdater.rank(rankableList, rankable1, 0);
         RankableConnectionUpdater.rank(rankableList, rankable2, 1);
         RankableConnectionUpdater.rank(rankableList, rankable3, 10);
-        RankableConnectionUpdater.rank(rankableList, rankable4, 10);
+        RankableConnectionUpdater.rank(rankableList, rankable4, 11);
         RankableConnectionUpdater.rank(rankableList, rankable5, 12);
         RankableConnectionUpdater.rank(rankableList, rankable6, 20);
         RankableConnectionUpdater.rank(rankableList, rankable7, 100);
@@ -122,16 +122,17 @@ public class RankableConnectionUpdaterTest {
         final var rankable3 = new TestRankable("urn:3", relevance, 10);
         final var rankable4 = new TestRankable("urn:4", relevance, 10);
         final var rankable5 = new TestRankable("urn:5", relevance, 10);
-        final var rankable6 = new TestRankable("urn:6", relevance, 10);
+        final var rankable6 = new TestRankable("urn:6", relevance, 20);
 
-        final var rankableList = Arrays.nonNullElementsIn(new TestRankable[]{rankable1, rankable2, rankable3, rankable4, rankable5, rankable6});
+        final var rankableList = Arrays.nonNullElementsIn(
+                new TestRankable[] { rankable1, rankable2, rankable3, rankable4, rankable5, rankable6 });
 
         assertEquals(0, rankable1.getRank());
         assertEquals(1, rankable2.getRank());
         assertEquals(10, rankable3.getRank());
         assertEquals(10, rankable4.getRank());
         assertEquals(10, rankable5.getRank());
-        assertEquals(10, rankable6.getRank());
+        assertEquals(20, rankable6.getRank());
 
         verifyOrder(rankableList, List.of("urn:1", "urn:2", "urn:3", "urn:4", "urn:5", "urn:6"));
 
@@ -143,7 +144,7 @@ public class RankableConnectionUpdaterTest {
         assertEquals(11, rankable3.getRank());
         assertEquals(12, rankable4.getRank());
         assertEquals(10, rankable5.getRank());
-        assertEquals(13, rankable6.getRank());
+        assertEquals(20, rankable6.getRank());
     }
 
     private static class TestRankable implements EntityWithPathConnection {

--- a/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
@@ -10,6 +10,7 @@ package no.ndla.taxonomy.service;
 import no.ndla.taxonomy.domain.EntityWithPath;
 import no.ndla.taxonomy.domain.EntityWithPathConnection;
 import no.ndla.taxonomy.domain.Relevance;
+import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
@@ -47,7 +48,7 @@ public class RankableConnectionUpdaterTest {
         RankableConnectionUpdater.rank(rankableList, rankable1, 0);
         RankableConnectionUpdater.rank(rankableList, rankable2, 1);
         RankableConnectionUpdater.rank(rankableList, rankable3, 10);
-        RankableConnectionUpdater.rank(rankableList, rankable4, 11);
+        RankableConnectionUpdater.rank(rankableList, rankable4, 10);
         RankableConnectionUpdater.rank(rankableList, rankable5, 12);
         RankableConnectionUpdater.rank(rankableList, rankable6, 20);
         RankableConnectionUpdater.rank(rankableList, rankable7, 100);
@@ -110,6 +111,39 @@ public class RankableConnectionUpdaterTest {
         assertEquals(20, rankable6.getRank());
         assertEquals(100, rankable7.getRank());
         assertEquals(11, rankable8.getRank());
+    }
+
+    @Test
+    public void rank_cascading() throws URISyntaxException {
+        final var relevance = new Relevance();
+
+        final var rankable1 = new TestRankable("urn:1", relevance, 0);
+        final var rankable2 = new TestRankable("urn:2", relevance, 1);
+        final var rankable3 = new TestRankable("urn:3", relevance, 10);
+        final var rankable4 = new TestRankable("urn:4", relevance, 10);
+        final var rankable5 = new TestRankable("urn:5", relevance, 10);
+        final var rankable6 = new TestRankable("urn:6", relevance, 10);
+
+        final var rankableList = Arrays.nonNullElementsIn(new TestRankable[]{rankable1, rankable2, rankable3, rankable4, rankable5, rankable6});
+
+        assertEquals(0, rankable1.getRank());
+        assertEquals(1, rankable2.getRank());
+        assertEquals(10, rankable3.getRank());
+        assertEquals(10, rankable4.getRank());
+        assertEquals(10, rankable5.getRank());
+        assertEquals(10, rankable6.getRank());
+
+        verifyOrder(rankableList, List.of("urn:1", "urn:2", "urn:3", "urn:4", "urn:5", "urn:6"));
+
+        RankableConnectionUpdater.rank(rankableList, rankable5, 10);
+        verifyOrder(rankableList, List.of("urn:1", "urn:2", "urn:5", "urn:3", "urn:4", "urn:6"));
+
+        assertEquals(0, rankable1.getRank());
+        assertEquals(1, rankable2.getRank());
+        assertEquals(11, rankable3.getRank());
+        assertEquals(12, rankable4.getRank());
+        assertEquals(10, rankable5.getRank());
+        assertEquals(13, rankable6.getRank());
     }
 
     private static class TestRankable implements EntityWithPathConnection {


### PR DESCRIPTION
Dersom det er fleire koblinger med samme rank, som vi veit vi har mange av, så hjelper ikkje dette på sorteringa fordi frontend sorterer samme rank litt tilfeldig.
Denne endringa gjør det slik at alle rank under en node blir unike, gitt at du forsøker å endre rank til en verdi som det finnes fleire av.

Ny test beskriver det best, der koblinger med samme rank endres slik at du ikkje lenger får samme rank for fleire ressurser under en node.