### PR TITLE
Metadata in connection

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/EntityWithMetadata.java
+++ b/src/main/java/no/ndla/taxonomy/domain/EntityWithMetadata.java
@@ -1,0 +1,12 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.domain;
+
+public interface EntityWithMetadata {
+    Metadata getMetadata();
+}

--- a/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
+++ b/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
@@ -15,7 +15,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 @MappedSuperclass
-public abstract class EntityWithPath extends DomainObject {
+public abstract class EntityWithPath extends DomainObject implements EntityWithMetadata {
     public abstract Set<CachedPath> getCachedPaths();
 
     public void addCachedPath(CachedPath cachedPath) {
@@ -97,8 +97,6 @@ public abstract class EntityWithPath extends DomainObject {
         return getCachedPaths().stream().filter(CachedPath::isActive).map(CachedPath::getPath)
                 .collect(Collectors.toCollection(TreeSet::new));
     }
-
-    abstract public Metadata getMetadata();
 
     abstract public URI getContentUri();
 

--- a/src/main/java/no/ndla/taxonomy/domain/NodeConnection.java
+++ b/src/main/java/no/ndla/taxonomy/domain/NodeConnection.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Entity
-public class NodeConnection extends DomainEntity implements EntityWithPathConnection {
+public class NodeConnection extends DomainEntity implements EntityWithMetadata, EntityWithPathConnection {
     @ManyToOne
     @JoinColumn(name = "parent_id")
     private Node parent;
@@ -29,6 +29,10 @@ public class NodeConnection extends DomainEntity implements EntityWithPathConnec
     @JoinColumn(name = "relevance_id")
     private Relevance relevance;
 
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, optional = false)
+    @JoinColumn(name = "metadata_id")
+    private Metadata metadata = new Metadata();
+
     private NodeConnection() {
         setPublicId(URI.create("urn:node-connection:" + UUID.randomUUID()));
     }
@@ -40,6 +44,7 @@ public class NodeConnection extends DomainEntity implements EntityWithPathConnec
         this.relevance = nodeConnection.relevance;
         this.parent = nodeConnection.parent;
         this.child = nodeConnection.child;
+        setMetadata(new Metadata(nodeConnection.getMetadata()));
     }
 
     public static NodeConnection create(Node parent, Node child) {
@@ -135,5 +140,13 @@ public class NodeConnection extends DomainEntity implements EntityWithPathConnec
     @Override
     public void setRelevance(Relevance relevance) {
         this.relevance = relevance;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/NodeResource.java
+++ b/src/main/java/no/ndla/taxonomy/domain/NodeResource.java
@@ -13,7 +13,8 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Entity
-public class NodeResource extends DomainEntity implements EntityWithPathConnection, SortableResourceConnection<Node> {
+public class NodeResource extends DomainEntity
+        implements EntityWithMetadata, EntityWithPathConnection, SortableResourceConnection<Node> {
 
     @ManyToOne
     @JoinColumn(name = "node_id")
@@ -33,6 +34,10 @@ public class NodeResource extends DomainEntity implements EntityWithPathConnecti
     @JoinColumn(name = "relevance_id")
     private Relevance relevance;
 
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, optional = false)
+    @JoinColumn(name = "metadata_id")
+    private Metadata metadata = new Metadata();
+
     private NodeResource() {
         setPublicId(URI.create("urn:node-resource:" + UUID.randomUUID()));
     }
@@ -44,6 +49,7 @@ public class NodeResource extends DomainEntity implements EntityWithPathConnecti
         this.node = nodeResource.node;
         this.resource = nodeResource.resource;
         setPublicId(nodeResource.getPublicId());
+        setMetadata(new Metadata(nodeResource.getMetadata()));
     }
 
     public static NodeResource create(Node node, Resource resource) {
@@ -141,5 +147,13 @@ public class NodeResource extends DomainEntity implements EntityWithPathConnecti
     @Override
     public void setRelevance(Relevance relevance) {
         this.relevance = relevance;
+    }
+
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
     }
 }

--- a/src/main/java/no/ndla/taxonomy/migration/CreateMetadataForConnectionsSqlChange.java
+++ b/src/main/java/no/ndla/taxonomy/migration/CreateMetadataForConnectionsSqlChange.java
@@ -1,0 +1,133 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2022 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.migration;
+
+import liquibase.change.custom.CustomSqlChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import liquibase.statement.SqlStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+public class CreateMetadataForConnectionsSqlChange implements CustomSqlChange {
+
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) throws CustomChangeException {
+        JdbcConnection connection = (JdbcConnection) database.getConnection();
+        try {
+            populateMetadataForTable(connection, "node_connection", "child_id", "node");
+            populateMetadataForTable(connection, "node_resource", "resource_id", "resource");
+        } catch (SQLException | DatabaseException exception) {
+            // Should just fail the migration. No updates are run before returning from this method,
+            // so no damage is done
+            throw new RuntimeException(exception);
+        }
+        return new SqlStatement[0];
+    }
+
+    private void populateMetadataForTable(JdbcConnection connection, String table, String childColumn, String childType)
+            throws SQLException, DatabaseException {
+        logger.info(String.format("Updating %s with metadata", table));
+        ResultSet result = connection.prepareStatement(String.format("SELECT id, %s from %s", childColumn, table))
+                .executeQuery();
+        if (result != null) {
+            while (result.next()) {
+                var connectionId = result.getInt(1);
+                var childId = result.getInt(2);
+                PreparedStatement getMetadataId = connection
+                        .prepareStatement(String.format("SELECT metadata_id from %s where id = ?", childType));
+                getMetadataId.setInt(1, childId);
+                ResultSet metadataIdRS = getMetadataId.executeQuery();
+                metadataIdRS.next();
+                int oldMetadataId = metadataIdRS.getInt(1);
+
+                PreparedStatement getMetadata = connection
+                        .prepareStatement("SELECT visible from metadata where id = ?");
+                getMetadata.setInt(1, oldMetadataId);
+                ResultSet metadataRs = getMetadata.executeQuery();
+                metadataRs.next();
+                boolean visible = metadataRs.getObject(1, Boolean.class);
+                PreparedStatement insertMetadata = connection
+                        .prepareStatement("insert into metadata (visible, created_at) values (?, ?) returning id");
+                insertMetadata.setBoolean(1, visible);
+                insertMetadata.setTimestamp(2, Timestamp.from(Instant.now()));
+                ResultSet resultSet = insertMetadata.executeQuery();
+                resultSet.next();
+                Integer newMetadataId = resultSet.getObject(1, Integer.class);
+
+                PreparedStatement getGrepCode = connection
+                        .prepareStatement("select grep_code_id from metadata_grep_code where metadata_id = ?");
+                getGrepCode.setInt(1, oldMetadataId);
+                ResultSet grepCodesRs = getGrepCode.executeQuery();
+                while (grepCodesRs.next()) {
+                    int grepCodeId = grepCodesRs.getInt(1);
+                    PreparedStatement insertGrepCode = connection.prepareStatement(
+                            "insert into metadata_grep_code (metadata_id, grep_code_id) values (?, ?)");
+                    insertGrepCode.setInt(1, newMetadataId);
+                    insertGrepCode.setInt(2, grepCodeId);
+                    insertGrepCode.executeUpdate();
+                }
+
+                PreparedStatement getCustomFields = connection.prepareStatement(
+                        "select custom_field_id, value from custom_field_value where metadata_id = ?");
+                getCustomFields.setInt(1, oldMetadataId);
+                ResultSet customFieldsRS = getCustomFields.executeQuery();
+                while (customFieldsRS.next()) {
+                    int customFieldId = customFieldsRS.getInt(1);
+                    String value = customFieldsRS.getString(2);
+                    PreparedStatement insertCustomField = connection.prepareStatement(
+                            "insert into custom_field_value (metadata_id, custom_field_id, value) values (?, ?, ?)");
+                    insertCustomField.setInt(1, newMetadataId);
+                    insertCustomField.setInt(2, customFieldId);
+                    insertCustomField.setString(3, value);
+                    insertCustomField.executeUpdate();
+                }
+
+                PreparedStatement updateTable = connection
+                        .prepareStatement(String.format("update %s set metadata_id = ? where id = ?", table));
+                updateTable.setInt(1, newMetadataId);
+                updateTable.setInt(2, connectionId);
+                updateTable.executeUpdate();
+            }
+        }
+
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Added metadata to connections from child";
+    }
+
+    @Override
+    public void setUp() throws SetupException {
+
+    }
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {
+
+    }
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return null;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/rest/v1/CrudControllerWithMetadata.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/CrudControllerWithMetadata.java
@@ -8,6 +8,7 @@
 package no.ndla.taxonomy.rest.v1;
 
 import io.swagger.annotations.ApiOperation;
+import no.ndla.taxonomy.domain.DomainEntity;
 import no.ndla.taxonomy.domain.DomainObject;
 import no.ndla.taxonomy.repositories.TaxonomyRepository;
 import no.ndla.taxonomy.service.CachedUrlUpdaterService;
@@ -22,7 +23,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.net.URI;
 
-public abstract class CrudControllerWithMetadata<T extends DomainObject> extends CrudController<T> {
+public abstract class CrudControllerWithMetadata<T extends DomainEntity> extends CrudController<T> {
     private final MetadataService metadataService;
 
     protected CrudControllerWithMetadata(TaxonomyRepository<T> repository,

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
@@ -14,10 +14,13 @@ import io.swagger.annotations.ApiParam;
 import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeConnection;
 import no.ndla.taxonomy.domain.Relevance;
+import no.ndla.taxonomy.domain.Resource;
 import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.repositories.RelevanceRepository;
+import no.ndla.taxonomy.service.CachedUrlUpdaterService;
 import no.ndla.taxonomy.service.EntityConnectionService;
+import no.ndla.taxonomy.service.MetadataService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -31,14 +34,16 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping(path = { "/v1/node-connections" })
 @Transactional
-public class NodeConnections {
+public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> {
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;
     private final EntityConnectionService connectionService;
     private final RelevanceRepository relevanceRepository;
 
     public NodeConnections(NodeRepository nodeRepository, NodeConnectionRepository nodeConnectionRepository,
-            EntityConnectionService connectionService, RelevanceRepository relevanceRepository) {
+            EntityConnectionService connectionService, RelevanceRepository relevanceRepository,
+            CachedUrlUpdaterService cachedUrlUpdaterService, MetadataService metadataService) {
+        super(nodeConnectionRepository, cachedUrlUpdaterService, metadataService);
         this.nodeRepository = nodeRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
         this.connectionService = connectionService;

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.rest.v1;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.ApiOperation;
@@ -21,6 +22,7 @@ import no.ndla.taxonomy.repositories.RelevanceRepository;
 import no.ndla.taxonomy.service.CachedUrlUpdaterService;
 import no.ndla.taxonomy.service.EntityConnectionService;
 import no.ndla.taxonomy.service.MetadataService;
+import no.ndla.taxonomy.service.dtos.MetadataDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -167,6 +169,10 @@ public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> 
         @ApiModelProperty(value = "Relevance id", example = "urn:relevance:core")
         public URI relevanceId;
 
+        @JsonProperty
+        @ApiModelProperty(value = "Metadata for entity. Read only.")
+        private MetadataDto metadata;
+
         ParentChildIndexDocument() {
         }
 
@@ -177,6 +183,7 @@ public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> 
             relevanceId = nodeConnection.getRelevance().map(Relevance::getPublicId).orElse(null);
             primary = true;
             rank = nodeConnection.getRank();
+            metadata = new MetadataDto(nodeConnection.getMetadata());
         }
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
@@ -185,7 +185,6 @@ public class NodeResources extends CrudControllerWithMetadata<NodeResource> {
         @ApiModelProperty(value = "Metadata for entity. Read only.")
         private MetadataDto metadata;
 
-
         NodeResourceDto() {
         }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
@@ -20,7 +20,10 @@ import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.repositories.NodeResourceRepository;
 import no.ndla.taxonomy.repositories.RelevanceRepository;
 import no.ndla.taxonomy.repositories.ResourceRepository;
+import no.ndla.taxonomy.service.CachedUrlUpdaterService;
 import no.ndla.taxonomy.service.EntityConnectionService;
+import no.ndla.taxonomy.service.MetadataService;
+import no.ndla.taxonomy.service.dtos.MetadataDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -34,7 +37,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping(path = { "/v1/node-resources" })
 @Transactional
-public class NodeResources {
+public class NodeResources extends CrudControllerWithMetadata<NodeResource> {
 
     private final NodeRepository nodeRepository;
     private final ResourceRepository resourceRepository;
@@ -44,7 +47,9 @@ public class NodeResources {
 
     public NodeResources(NodeRepository nodeRepository, ResourceRepository resourceRepository,
             NodeResourceRepository nodeResourceRepository, EntityConnectionService connectionService,
-            RelevanceRepository relevanceRepository) {
+            RelevanceRepository relevanceRepository, CachedUrlUpdaterService cachedUrlUpdaterService,
+            MetadataService metadataService) {
+        super(nodeResourceRepository, cachedUrlUpdaterService, metadataService);
         this.nodeRepository = nodeRepository;
         this.resourceRepository = resourceRepository;
         this.nodeResourceRepository = nodeResourceRepository;
@@ -177,6 +182,10 @@ public class NodeResources {
         @ApiModelProperty(value = "Relevance id", example = "urn:relevance:core")
         public URI relevanceId;
 
+        @ApiModelProperty(value = "Metadata for entity. Read only.")
+        private MetadataDto metadata;
+
+
         NodeResourceDto() {
         }
 
@@ -187,6 +196,7 @@ public class NodeResources {
             primary = nodeResource.isPrimary().orElse(false);
             rank = nodeResource.getRank();
             relevanceId = nodeResource.getRelevance().map(Relevance::getPublicId).orElse(null);
+            metadata = new MetadataDto(nodeResource.getMetadata());
         }
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperService.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperService.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.domain.EntityWithMetadata;
 import no.ndla.taxonomy.domain.EntityWithPath;
 import no.ndla.taxonomy.domain.Node;
 
@@ -15,5 +16,5 @@ import java.net.URI;
 public interface DomainEntityHelperService {
     Node getNodeByPublicId(URI publicId);
 
-    EntityWithPath getEntityByPublicId(URI publicId);
+    EntityWithMetadata getEntityByPublicId(URI publicId);
 }

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
@@ -49,11 +49,7 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
     public EntityWithMetadata getEntityByPublicId(URI publicId) {
         switch (publicId.getSchemeSpecificPart().split(":")[0]) {
         case "subject":
-            return nodeRepository.findFirstByPublicId(publicId)
-                    .orElseThrow(() -> new NotFoundServiceException("Subject by id was not found"));
         case "topic":
-            return nodeRepository.findFirstByPublicId(publicId)
-                    .orElseThrow(() -> new NotFoundServiceException("Topic by id was not found"));
         case "node":
             return nodeRepository.findFirstByPublicId(publicId)
                     .orElseThrow(() -> new NotFoundServiceException("Node by id was not found"));

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
@@ -7,9 +7,13 @@
 
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.domain.EntityWithMetadata;
 import no.ndla.taxonomy.domain.EntityWithPath;
 import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.NodeConnection;
+import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
+import no.ndla.taxonomy.repositories.NodeResourceRepository;
 import no.ndla.taxonomy.repositories.ResourceRepository;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.springframework.stereotype.Component;
@@ -22,10 +26,15 @@ import java.net.URI;
 public class DomainEntityHelperServiceImpl implements DomainEntityHelperService {
     private final NodeRepository nodeRepository;
     private final ResourceRepository resourceRepository;
+    private final NodeConnectionRepository nodeConnectionRepository;
+    private final NodeResourceRepository nodeResourceRepository;
 
-    public DomainEntityHelperServiceImpl(NodeRepository nodeRepository, ResourceRepository resourceRepository) {
+    public DomainEntityHelperServiceImpl(NodeRepository nodeRepository, ResourceRepository resourceRepository,
+            NodeConnectionRepository nodeConnectionRepository, NodeResourceRepository nodeResourceRepository) {
         this.nodeRepository = nodeRepository;
         this.resourceRepository = resourceRepository;
+        this.nodeConnectionRepository = nodeConnectionRepository;
+        this.nodeResourceRepository = nodeResourceRepository;
     }
 
     @Override
@@ -37,7 +46,7 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
 
     @Override
     @Transactional(propagation = Propagation.MANDATORY)
-    public EntityWithPath getEntityByPublicId(URI publicId) {
+    public EntityWithMetadata getEntityByPublicId(URI publicId) {
         switch (publicId.getSchemeSpecificPart().split(":")[0]) {
         case "subject":
             return nodeRepository.findFirstByPublicId(publicId)
@@ -51,6 +60,15 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
         case "resource":
             return resourceRepository.findFirstByPublicId(publicId)
                     .orElseThrow(() -> new NotFoundServiceException("Resource by id was not found"));
+        case "node-connection":
+        case "subject-topic":
+        case "topic-subtopic":
+            return nodeConnectionRepository.findFirstByPublicId(publicId)
+                    .orElseThrow(() -> new NotFoundServiceException("NodeConnection by id was not found"));
+        case "node-resource":
+        case "topic-resource":
+            return nodeResourceRepository.findFirstByPublicId(publicId)
+                    .orElseThrow(() -> new NotFoundServiceException("NodeResource by id was not found"));
         }
 
         throw new NotFoundServiceException("Unknown entity requested");

--- a/src/main/java/no/ndla/taxonomy/service/MetadataServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/MetadataServiceImpl.java
@@ -7,10 +7,7 @@
 
 package no.ndla.taxonomy.service;
 
-import no.ndla.taxonomy.domain.EntityWithMetadata;
-import no.ndla.taxonomy.domain.EntityWithPath;
-import no.ndla.taxonomy.domain.GrepCode;
-import no.ndla.taxonomy.domain.Metadata;
+import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.service.dtos.MetadataDto;
 import no.ndla.taxonomy.service.exceptions.EntityNotFoundException;
 import no.ndla.taxonomy.service.exceptions.InvalidDataException;
@@ -45,8 +42,17 @@ public class MetadataServiceImpl implements MetadataService {
     public MetadataDto updateMetadataByPublicId(URI publicId, MetadataDto metadataDto) throws InvalidDataException {
         EntityWithMetadata entity = domainEntityHelperService.getEntityByPublicId(publicId);
         Metadata metadata = entity.getMetadata();
-
         mergeMetadata(metadata, metadataDto);
+
+        // Temporary update child relation when updating connection
+        if (entity instanceof NodeResource) {
+            Metadata resourceMetadata = ((NodeResource) entity).getResource().get().getMetadata();
+            mergeMetadata(resourceMetadata, metadataDto);
+        }
+        if (entity instanceof NodeConnection) {
+            Metadata connectionMetadata = ((NodeConnection) entity).getChild().get().getMetadata();
+            mergeMetadata(connectionMetadata, metadataDto);
+        }
 
         return new MetadataDto(metadata);
     }

--- a/src/main/java/no/ndla/taxonomy/service/MetadataServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/MetadataServiceImpl.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.service;
 
+import no.ndla.taxonomy.domain.EntityWithMetadata;
 import no.ndla.taxonomy.domain.EntityWithPath;
 import no.ndla.taxonomy.domain.GrepCode;
 import no.ndla.taxonomy.domain.Metadata;
@@ -36,13 +37,13 @@ public class MetadataServiceImpl implements MetadataService {
 
     @Override
     public MetadataDto getMetadataByPublicId(URI publicId) {
-        EntityWithPath entity = domainEntityHelperService.getEntityByPublicId(publicId);
+        EntityWithMetadata entity = domainEntityHelperService.getEntityByPublicId(publicId);
         return new MetadataDto(entity.getMetadata());
     }
 
     @Override
     public MetadataDto updateMetadataByPublicId(URI publicId, MetadataDto metadataDto) throws InvalidDataException {
-        EntityWithPath entity = domainEntityHelperService.getEntityByPublicId(publicId);
+        EntityWithMetadata entity = domainEntityHelperService.getEntityByPublicId(publicId);
         Metadata metadata = entity.getMetadata();
 
         mergeMetadata(metadata, metadataDto);

--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
@@ -74,7 +74,8 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
 
     public EntityWithPathChildDTO(Node node, NodeConnection nodeConnection, String language) {
         this.language = language;
-        this.metadata = new MetadataDto(nodeConnection.getMetadata());
+        // This must be enabled when ed is updated to update metadata for connections.
+        // this.metadata = new MetadataDto(nodeConnection.getMetadata());
 
         nodeConnection.getChild().ifPresent(child -> {
             this.populateFromNode(child);
@@ -86,6 +87,7 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
                     .collect(Collectors.toCollection(TreeSet::new));
             this.supportedLanguages = this.translations.stream().map(t -> t.language)
                     .collect(Collectors.toCollection(TreeSet::new));
+            this.metadata = new MetadataDto(child.getMetadata());
         });
 
         nodeConnection.getParent().ifPresent(parent -> this.parent = parent.getPublicId());

--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
@@ -74,12 +74,13 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
 
     public EntityWithPathChildDTO(Node node, NodeConnection nodeConnection, String language) {
         this.language = language;
+        this.metadata = new MetadataDto(nodeConnection.getMetadata());
 
         nodeConnection.getChild().ifPresent(child -> {
             this.populateFromNode(child);
             this.path = child.getPathByContext(node).orElse("");
             this.paths = child.getAllPaths();
-            this.metadata = new MetadataDto(child.getMetadata());
+            // this.metadata = new MetadataDto(child.getMetadata());
 
             var translations = child.getTranslations();
             this.translations = translations.stream().map(TranslationDTO::new)

--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
@@ -80,7 +80,6 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
             this.populateFromNode(child);
             this.path = child.getPathByContext(node).orElse("");
             this.paths = child.getAllPaths();
-            // this.metadata = new MetadataDto(child.getMetadata());
 
             var translations = child.getTranslations();
             this.translations = translations.stream().map(TranslationDTO::new)

--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathDTO.java
@@ -9,7 +9,10 @@ package no.ndla.taxonomy.service.dtos;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
-import no.ndla.taxonomy.domain.*;
+import no.ndla.taxonomy.domain.EntityWithPath;
+import no.ndla.taxonomy.domain.EntityWithPathConnection;
+import no.ndla.taxonomy.domain.Relevance;
+import no.ndla.taxonomy.domain.Translation;
 import no.ndla.taxonomy.rest.v1.NodeTranslations.TranslationDTO;
 
 import java.net.URI;

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeConnectionIndexDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeConnectionIndexDTO.java
@@ -77,6 +77,7 @@ public class NodeConnectionIndexDTO implements TreeSorter.Sortable {
         this.isPrimary = true;
 
         this.rank = nodeConnection.getRank();
+        this.metadata = new MetadataDto(nodeConnection.getMetadata());
 
         nodeConnection.getParent().ifPresent(topic -> this.parentId = topic.getPublicId());
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithResourceConnectionDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithResourceConnectionDTO.java
@@ -7,8 +7,10 @@
 
 package no.ndla.taxonomy.service.dtos;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.ApiParam;
 import no.ndla.taxonomy.domain.NodeResource;
 import no.ndla.taxonomy.domain.Relevance;
@@ -31,6 +33,10 @@ public class NodeWithResourceConnectionDTO extends NodeDTO {
     @ApiParam
     private URI relevanceId;
 
+    @ApiModelProperty(value = "Metadata for entity. Read only.")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private MetadataDto metadata;
+
     public NodeWithResourceConnectionDTO(NodeResource nodeResource, String language) {
         super(nodeResource.getNode().orElseThrow(() -> new NotFoundException("Node was not found")), language);
 
@@ -39,6 +45,7 @@ public class NodeWithResourceConnectionDTO extends NodeDTO {
         this.rank = nodeResource.getRank();
         this.relevanceId = nodeResource.getRelevance().map(Relevance::getPublicId)
                 .orElse(URI.create("urn:relevance:core"));
+        this.metadata = new MetadataDto(nodeResource.getMetadata());
     }
 
     public NodeWithResourceConnectionDTO() {
@@ -60,6 +67,11 @@ public class NodeWithResourceConnectionDTO extends NodeDTO {
     @Override
     public URI getRelevanceId() {
         return relevanceId;
+    }
+
+    @Override
+    public MetadataDto getMetadata() {
+        return metadata;
     }
 
     @Override

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -983,4 +983,26 @@
         <dropTable tableName="subject_translation"/>
         <dropTable tableName="subject"/>
     </changeSet>
+
+    <!-- metadata for connection object -->
+    <changeSet id="20220920 add metadata to connections" author="Gunnar Velle">
+        <addColumn tableName="node_connection">
+            <column name="metadata_id" type="integer"/>
+        </addColumn>
+        <addColumn tableName="node_resource">
+            <column name="metadata_id" type="integer"/>
+        </addColumn>
+        <addForeignKeyConstraint baseTableName="node_connection" baseColumnNames="metadata_id"
+                                 constraintName="fk_node_connection_metadata_id"
+                                 referencedTableName="metadata" referencedColumnNames="id"
+                                 onDelete="RESTRICT" onUpdate="RESTRICT"/>
+        <addForeignKeyConstraint baseTableName="node_resource" baseColumnNames="metadata_id"
+                                 constraintName="fk_node_resource_metadata_id"
+                                 referencedTableName="metadata" referencedColumnNames="id"
+                                 onDelete="RESTRICT" onUpdate="RESTRICT"/>
+    </changeSet>
+    <changeSet id="20220920 populate connections with metadata" author="Gunnar Velle">
+        <customChange class="no.ndla.taxonomy.migration.CreateMetadataForConnectionsSqlChange"/>
+    </changeSet>
+    <!-- end metadata for connection object -->
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImplTest.java
@@ -10,7 +10,9 @@ package no.ndla.taxonomy.service;
 import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeType;
 import no.ndla.taxonomy.domain.Resource;
+import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
+import no.ndla.taxonomy.repositories.NodeResourceRepository;
 import no.ndla.taxonomy.repositories.ResourceRepository;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,8 +44,11 @@ class DomainEntityHelperServiceImplTest {
     private DomainEntityHelperServiceImpl service;
 
     @BeforeEach
-    void setUp(@Autowired NodeRepository nodeRepository, @Autowired ResourceRepository resourceRepository) {
-        service = new DomainEntityHelperServiceImpl(nodeRepository, resourceRepository);
+    void setUp(@Autowired NodeRepository nodeRepository, @Autowired ResourceRepository resourceRepository,
+            @Autowired NodeConnectionRepository nodeConnectionRepository,
+            @Autowired NodeResourceRepository nodeResourceRepository) {
+        service = new DomainEntityHelperServiceImpl(nodeRepository, resourceRepository, nodeConnectionRepository,
+                nodeResourceRepository);
 
         topic1 = new Node(NodeType.TOPIC);
         topic1.setPublicId(URI.create("urn:topic:test:1"));

--- a/src/test/java/no/ndla/taxonomy/service/MetadataServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/MetadataServiceImplTest.java
@@ -7,14 +7,16 @@
 
 package no.ndla.taxonomy.service;
 
-import no.ndla.taxonomy.domain.Builder;
-import no.ndla.taxonomy.domain.NodeType;
+import no.ndla.taxonomy.domain.*;
+import no.ndla.taxonomy.repositories.NodeConnectionRepository;
+import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.service.dtos.MetadataDto;
 import no.ndla.taxonomy.service.exceptions.InvalidDataException;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -34,15 +36,20 @@ class MetadataServiceImplTest {
     private CustomFieldService customFieldService;
     private MetadataServiceImpl metadataService;
     private Builder builder;
+    private NodeRepository nodeRepository;
+    private NodeConnectionRepository nodeConnectionRepository;
 
     @BeforeEach
     void setUp(@Autowired CustomFieldService customFieldService,
             @Autowired DomainEntityHelperService domainEntityHelperService, @Autowired GrepCodeService grepCodeService,
-            @Autowired Builder builder) {
+            @Autowired Builder builder, @Autowired NodeConnectionRepository nodeConnectionRepository,
+            @Autowired NodeRepository nodeRepository) {
         this.domainEntityHelperService = domainEntityHelperService;
         this.grepCodeService = grepCodeService;
         this.customFieldService = customFieldService;
         this.builder = builder;
+        this.nodeRepository = nodeRepository;
+        this.nodeConnectionRepository = nodeConnectionRepository;
         metadataService = new MetadataServiceImpl(domainEntityHelperService, grepCodeService, customFieldService);
     }
 
@@ -73,16 +80,77 @@ class MetadataServiceImplTest {
         URI publicId = builder.node().getPublicId();
 
         MetadataDto metadata = new MetadataDto();
-
         metadata.setVisible(false);
         metadata.setGrepCodes(Set.of("KM123"));
         metadata.setCustomFields(Map.of("Gunnar", "ruler"));
 
-        MetadataDto updatedMetadata = metadataService.updateMetadataByPublicId(publicId, metadata);
-        assertFalse(updatedMetadata.isVisible());
-        assertTrue(updatedMetadata.getGrepCodes().contains("KM123"));
-        assertTrue(updatedMetadata.getCustomFields().containsKey("Gunnar"));
-        assertTrue(updatedMetadata.getCustomFields().containsValue("ruler"));
+        metadataService.updateMetadataByPublicId(publicId, metadata);
+        Node node = nodeRepository.getByPublicId(publicId);
+
+        MetadataDto metadataDto = new MetadataDto(node.getMetadata());
+        assertFalse(metadataDto.isVisible());
+        assertTrue(metadataDto.getGrepCodes().contains("KM123"));
+        assertTrue(metadataDto.getCustomFields().containsKey("Gunnar"));
+        assertTrue(metadataDto.getCustomFields().containsValue("ruler"));
+    }
+
+    @Test
+    @Transactional
+    void update_metadata_for_nodeConnection_updates_child() throws InvalidDataException {
+        Node child = builder.node();
+        Node parent = builder.node(n -> n.child(child));
+        NodeConnection connection = parent.getChildren().stream().findFirst().get();
+
+        MetadataDto metadata = new MetadataDto();
+        metadata.setVisible(false);
+        metadata.setGrepCodes(Set.of("KM123"));
+        metadata.setCustomFields(Map.of("Gunnar", "ruler"));
+
+        metadataService.updateMetadataByPublicId(connection.getPublicId(), metadata);
+        NodeConnection updated = nodeConnectionRepository.findByPublicId(connection.getPublicId());
+        MetadataDto connectionMetadata = new MetadataDto(updated.getMetadata());
+        assertFalse(connectionMetadata.isVisible());
+        assertTrue(connectionMetadata.getGrepCodes().contains("KM123"));
+        assertTrue(connectionMetadata.getCustomFields().containsKey("Gunnar"));
+        assertTrue(connectionMetadata.getCustomFields().containsValue("ruler"));
+
+        Node node = nodeRepository.getByPublicId(child.getPublicId());
+        MetadataDto childMetadata = new MetadataDto(node.getMetadata());
+        assertFalse(childMetadata.isVisible());
+        assertTrue(childMetadata.getGrepCodes().contains("KM123"));
+        assertTrue(childMetadata.getCustomFields().containsKey("Gunnar"));
+        assertTrue(childMetadata.getCustomFields().containsValue("ruler"));
+    }
+
+    @Test
+    @Transactional
+    void update_metadata_for_nodeConnection_does_not_update_child_if_value_is_set() throws InvalidDataException {
+        Node child = builder.node();
+        Node parent = builder.node(n -> n.child(child));
+        NodeConnection connection = parent.getChildren().stream().findFirst().get();
+
+        MetadataDto metadata = new MetadataDto();
+        metadata.setVisible(false);
+        metadata.setGrepCodes(Set.of("KM123"));
+        metadata.setCustomFields(Map.of("Gunnar", "ruler"));
+
+        // Turn off updating children
+        metadataService.setUpdateChildRelation(false);
+
+        metadataService.updateMetadataByPublicId(connection.getPublicId(), metadata);
+        NodeConnection updated = nodeConnectionRepository.findByPublicId(connection.getPublicId());
+        MetadataDto connectionMetadata = new MetadataDto(updated.getMetadata());
+        assertFalse(connectionMetadata.isVisible());
+        assertTrue(connectionMetadata.getGrepCodes().contains("KM123"));
+        assertTrue(connectionMetadata.getCustomFields().containsKey("Gunnar"));
+        assertTrue(connectionMetadata.getCustomFields().containsValue("ruler"));
+
+        Node node = nodeRepository.getByPublicId(child.getPublicId());
+        MetadataDto childMetadata = new MetadataDto(node.getMetadata());
+        assertTrue(childMetadata.isVisible());
+        assertFalse(childMetadata.getGrepCodes().contains("KM123"));
+        assertFalse(childMetadata.getCustomFields().containsKey("Gunnar"));
+        assertFalse(childMetadata.getCustomFields().containsValue("ruler"));
     }
 
 }

--- a/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/RankableConnectionUpdaterTest.java
@@ -126,8 +126,8 @@ public class RankableConnectionUpdaterTest {
         final var rankable7 = new TestRankable("urn:7", relevance, 13);
         final var rankable8 = new TestRankable("urn:8", relevance, 20);
 
-        final var rankableList = Arrays.nonNullElementsIn(
-                new TestRankable[] { rankable1, rankable2, rankable3, rankable4, rankable5, rankable6, rankable7, rankable8 });
+        final var rankableList = Arrays.nonNullElementsIn(new TestRankable[] { rankable1, rankable2, rankable3,
+                rankable4, rankable5, rankable6, rankable7, rankable8 });
 
         assertEquals(0, rankable1.getRank());
         assertEquals(1, rankable2.getRank());


### PR DESCRIPTION
Legger til støtte for metadata for koblingsobjekt. 
Trengs etter kvart for at vi skal kunne sette customfelt på koblinger. Dette gjør også at synlighet ikkje lenger trenger å settes på en ressurs, men kan styres for kvar plassering en ressurs har i taksonomien.