### PR TITLE
Adding support for env variables for swaggerdoc

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/SwaggerConfiguration.java
+++ b/src/main/java/no/ndla/taxonomy/config/SwaggerConfiguration.java
@@ -20,19 +20,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
-import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.builders.RequestParameterBuilder;
 import springfox.documentation.schema.ScalarType;
 import springfox.documentation.service.*;
 import springfox.documentation.spi.DocumentationType;
-import springfox.documentation.spi.service.ParameterBuilderPlugin;
 import springfox.documentation.spi.service.contexts.SecurityContext;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
-import java.lang.reflect.Parameter;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,7 +37,7 @@ import java.util.List;
 
 import static com.google.common.collect.Sets.newHashSet;
 import static java.util.Collections.emptyList;
-import static org.springframework.http.MediaType.APPLICATION_JSON_UTF8;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 @Configuration
 @EnableSwagger2
@@ -48,6 +45,18 @@ public class SwaggerConfiguration {
 
     @Value(value = "${auth0.issuer}")
     private String issuer;
+
+    @Value(value = "${contact.name:NDLA}")
+    private String contactName;
+
+    @Value(value = "${contact.email:hjelp+api@ndla.no}")
+    private String contactEmail;
+
+    @Value(value = "${contact.url:https://ndla.no}")
+    private String contactUrl;
+
+    @Value(value = "${terms.url:https://om.ndla.no/tos}")
+    private String termsUrl;
 
     @Bean
     public Docket api() {
@@ -59,8 +68,8 @@ public class SwaggerConfiguration {
                 .globalRequestParameters(List.of(new RequestParameterBuilder().name("VersionHash")
                         .description("Hash code identifying taxonomy version.").in(ParameterType.HEADER)
                         .query(q -> q.model(m -> m.scalarModel(ScalarType.STRING))).build()))
-                .useDefaultResponseMessages(true).produces(newHashSet(APPLICATION_JSON_UTF8.toString()))
-                .consumes(newHashSet(APPLICATION_JSON_UTF8.toString()));
+                .useDefaultResponseMessages(true).produces(newHashSet(APPLICATION_JSON.toString()))
+                .consumes(newHashSet(APPLICATION_JSON.toString()));
     }
 
     private OAuth securitySchema() {
@@ -78,15 +87,14 @@ public class SwaggerConfiguration {
     }
 
     private Contact contact() {
-        return new Contact("NDLA", "https://ndla.no", "support+api@ndla.no");
+        return new Contact(contactName, contactUrl, contactEmail);
     }
 
     private ApiInfo apiInfo() {
         return new ApiInfo("NDLA Taxonomy API", "Rest service and graph database for organizing content.\n\n"
                 + "Unless otherwise specified, all PUT and POST requests must use Content-Type: application/json;charset=UTF-8. If charset is omitted, UTF-8 will be assumed. All GET requests will return data using the same content type.\n\n"
                 + "When you remove an entity, its associations are also deleted. E.g., if you remove a subject, its associations to any topics are removed. The topics themselves are not affected.",
-                "v1", "https://om.ndla.no/tos", contact(), "GPL 3.0", "https://www.gnu.org/licenses/gpl-3.0.en.html",
-                emptyList());
+                "v1", termsUrl, contact(), "GPL 3.0", "https://www.gnu.org/licenses/gpl-3.0.en.html", emptyList());
     }
 
     /*


### PR DESCRIPTION
La til mulighet for å overstyre swagger med miljøvariabler. 
Spring oversetter automatisk CONTACT_NAME til contact.name så andre endringer enn dette trengs ikkje. Uansett er default-verdier satt til det korrekte.