### PR TITLE
Use native query to ensure versions are fetched from db always.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/VersionRepository.java
@@ -9,17 +9,22 @@ package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Version;
 import no.ndla.taxonomy.domain.VersionType;
+import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
 public interface VersionRepository extends TaxonomyRepository<Version> {
+    @Query(value = "SELECT * from Version v where v.public_id = :#{#publicId.toString()}", nativeQuery = true)
     Optional<Version> findFirstByPublicId(URI publicId);
 
+    @Query(value = "SELECT * from Version v where v.hash = :hash", nativeQuery = true)
     Optional<Version> findFirstByHash(String hash);
 
+    @Query(value = "SELECT * from Version v where v.version_type = :#{#versionType.name()}", nativeQuery = true)
     List<Version> findByVersionType(VersionType versionType);
 
+    @Query(value = "SELECT * from Version v where v.version_type = :#{#versionType.name()}", nativeQuery = true)
     Optional<Version> findFirstByVersionType(VersionType versionType);
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Versions.java
@@ -20,6 +20,7 @@ import no.ndla.taxonomy.service.exceptions.InvalidArgumentServiceException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
@@ -85,8 +86,8 @@ public class Versions extends CrudController<Version> {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @Override
     public void delete(@PathVariable("id") URI id) {
-        Version version = versionRepository.getByPublicId(id);
-        if (version == null || version.isLocked()) {
+        Optional<Version> version = versionRepository.findFirstByPublicId(id);
+        if (version.isEmpty() || version.get().isLocked()) {
             throw new InvalidArgumentServiceException("Cannot delete locked version");
         }
         versionService.delete(id);
@@ -97,8 +98,8 @@ public class Versions extends CrudController<Version> {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
     public void publish(@PathVariable("id") URI id) {
-        Version version = versionRepository.getByPublicId(id);
-        if (version == null || version.getVersionType() != VersionType.BETA) {
+        Optional<Version> version = versionRepository.findFirstByPublicId(id);
+        if (version.isEmpty() || version.get().getVersionType() != VersionType.BETA) {
             throw new InvalidArgumentServiceException("Version has wrong type");
         }
         versionService.publishBetaAndArchiveCurrent(id);


### PR DESCRIPTION
Dette skal fikse et veldig konkret problem. Nemlig at siden vi kjører fleire servere, og hibernate bruker cache, så vil ikkje edringer på en server gjenspeiles på dei andre serverene med en gong. Spesielt gjelder dette om noen lager en ny taksonomiversjon, og så forsøker å publisere endringer til den nye versjonen. Då har du ingen måte å garantere at ny versjon finnes på serveren du treffer ved publisering, og dermed feiler publiseringa.

Native-spørringer går forbi cachen og henter fra db for kvart kall.

Ulempa med dette er nok at henting av versjoner alltid vil gå til base og ikkje treffe cache, så antall faktiske spørringer går opp, og sannsynligvis vil det kunne medføre en ytelseshit.