### PR TITLE
Use same functionality for /page and /search

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
@@ -7,7 +7,6 @@
 
 package no.ndla.taxonomy.rest.v1;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.annotations.ApiModelProperty;
 import io.swagger.annotations.ApiOperation;
@@ -15,7 +14,6 @@ import io.swagger.annotations.ApiParam;
 import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeConnection;
 import no.ndla.taxonomy.domain.Relevance;
-import no.ndla.taxonomy.domain.Resource;
 import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.repositories.RelevanceRepository;
@@ -68,7 +66,10 @@ public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> 
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
-        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get(), pageSize.get()));
+        if (page.get() < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeConnectionRepository.findByIds(ids.getContent());
         var contents = results.stream().map(ParentChildIndexDocument::new).collect(Collectors.toList());
         return new NodeConnectionPage(ids.getTotalElements(), contents);
@@ -166,14 +167,14 @@ public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> 
 
         @JsonProperty
         @ApiModelProperty(value = "Page containing results")
-        public List<ParentChildIndexDocument> page;
+        public List<ParentChildIndexDocument> results;
 
         NodeConnectionPage() {
         }
 
-        NodeConnectionPage(long totalCount, List<ParentChildIndexDocument> page) {
+        NodeConnectionPage(long totalCount, List<ParentChildIndexDocument> results) {
             this.totalCount = totalCount;
-            this.page = page;
+            this.results = results;
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
@@ -24,7 +24,6 @@ import no.ndla.taxonomy.service.CachedUrlUpdaterService;
 import no.ndla.taxonomy.service.EntityConnectionService;
 import no.ndla.taxonomy.service.MetadataService;
 import no.ndla.taxonomy.service.dtos.MetadataDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -76,7 +75,10 @@ public class NodeResources extends CrudControllerWithMetadata<NodeResource> {
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
-        var ids = nodeResourceRepository.findIdsPaginated(PageRequest.of(page.get(), pageSize.get()));
+        if (page.get() < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var ids = nodeResourceRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeResourceRepository.findByIds(ids.getContent());
         var contents = results.stream().map(NodeResourceDto::new).collect(Collectors.toList());
         return new NodeResourceDtoPage(ids.getTotalElements(), contents);
@@ -181,14 +183,14 @@ public class NodeResources extends CrudControllerWithMetadata<NodeResource> {
 
         @JsonProperty
         @ApiModelProperty(value = "Page containing results")
-        public List<NodeResourceDto> page;
+        public List<NodeResourceDto> results;
 
         NodeResourceDtoPage() {
         }
 
-        NodeResourceDtoPage(long totalCount, List<NodeResourceDto> page) {
+        NodeResourceDtoPage(long totalCount, List<NodeResourceDto> results) {
             this.totalCount = totalCount;
-            this.page = page;
+            this.results = results;
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/SubjectTopics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/SubjectTopics.java
@@ -59,7 +59,10 @@ public class SubjectTopics {
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
-        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get(), pageSize.get()));
+        if (page.get() < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeConnectionRepository.findByIds(ids.getContent());
         var contents = results.stream().map(SubjectTopicIndexDocument::new).collect(Collectors.toList());
         return new SubjectTopicPage(ids.getTotalElements(), contents);
@@ -158,14 +161,14 @@ public class SubjectTopics {
 
         @JsonProperty
         @ApiModelProperty(value = "Page containing results")
-        public List<SubjectTopicIndexDocument> page;
+        public List<SubjectTopicIndexDocument> results;
 
         SubjectTopicPage() {
         }
 
-        SubjectTopicPage(long totalCount, List<SubjectTopicIndexDocument> page) {
+        SubjectTopicPage(long totalCount, List<SubjectTopicIndexDocument> results) {
             this.totalCount = totalCount;
-            this.page = page;
+            this.results = results;
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/TopicResources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/TopicResources.java
@@ -63,7 +63,10 @@ public class TopicResources {
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
-        var ids = nodeResourceRepository.findIdsPaginated(PageRequest.of(page.get(), pageSize.get()));
+        if (page.get() < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var ids = nodeResourceRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeResourceRepository.findByIds(ids.getContent());
         var contents = results.stream().map(TopicResourceIndexDocument::new).collect(Collectors.toList());
         return new TopicResourcePage(ids.getTotalElements(), contents);
@@ -168,14 +171,14 @@ public class TopicResources {
 
         @JsonProperty
         @ApiModelProperty(value = "Page containing results")
-        public List<TopicResourceIndexDocument> page;
+        public List<TopicResourceIndexDocument> results;
 
         TopicResourcePage() {
         }
 
-        TopicResourcePage(long totalCount, List<TopicResourceIndexDocument> page) {
+        TopicResourcePage(long totalCount, List<TopicResourceIndexDocument> results) {
             this.totalCount = totalCount;
-            this.page = page;
+            this.results = results;
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/TopicSubtopics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/TopicSubtopics.java
@@ -61,7 +61,10 @@ public class TopicSubtopics {
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
-        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get(), pageSize.get()));
+        if (page.get() < 1)
+            throw new IllegalArgumentException("page parameter must be bigger than 0");
+
+        var ids = nodeConnectionRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeConnectionRepository.findByIds(ids.getContent());
         var contents = results.stream().map(TopicSubtopics.TopicSubtopicIndexDocument::new)
                 .collect(Collectors.toList());
@@ -160,14 +163,14 @@ public class TopicSubtopics {
 
         @JsonProperty
         @ApiModelProperty(value = "Page containing results")
-        public List<TopicSubtopicIndexDocument> page;
+        public List<TopicSubtopicIndexDocument> results;
 
         TopicSubtopicPage() {
         }
 
-        TopicSubtopicPage(long totalCount, List<TopicSubtopicIndexDocument> page) {
+        TopicSubtopicPage(long totalCount, List<TopicSubtopicIndexDocument> results) {
             this.totalCount = totalCount;
-            this.page = page;
+            this.results = results;
         }
     }
 

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
@@ -101,17 +101,17 @@ public class NodeConnectionsTest extends RestTest {
     public void can_get_node_connections_paginated() throws Exception {
         List<NodeConnection> connections = createTenContiguousRankedConnections();
 
-        MockHttpServletResponse response = testUtils.getResource("/v1/node-connections/page?page=0&pageSize=5");
+        MockHttpServletResponse response = testUtils.getResource("/v1/node-connections/page?page=1&pageSize=5");
         NodeConnections.NodeConnectionPage page1 = testUtils.getObject(NodeConnections.NodeConnectionPage.class,
                 response);
-        assertEquals(5, page1.page.size());
+        assertEquals(5, page1.results.size());
 
-        MockHttpServletResponse response2 = testUtils.getResource("/v1/node-connections/page?page=1&pageSize=5");
+        MockHttpServletResponse response2 = testUtils.getResource("/v1/node-connections/page?page=2&pageSize=5");
         NodeConnections.NodeConnectionPage page2 = testUtils.getObject(NodeConnections.NodeConnectionPage.class,
                 response2);
-        assertEquals(5, page2.page.size());
+        assertEquals(5, page2.results.size());
 
-        var result = Stream.concat(page1.page.stream(), page2.page.stream()).collect(Collectors.toList());
+        var result = Stream.concat(page1.results.stream(), page2.results.stream()).collect(Collectors.toList());
 
         assertTrue(connections.stream().map(DomainEntity::getPublicId).collect(Collectors.toList())
                 .containsAll(result.stream().map(r -> r.id).collect(Collectors.toList())));

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
@@ -192,17 +192,17 @@ public class NodeResourcesTest extends RestTest {
     public void can_get_resource_connections_paginated() throws Exception {
         List<NodeResource> connections = createTenContiguousRankedConnections();
 
-        MockHttpServletResponse response = testUtils.getResource("/v1/node-resources/page?page=0&pageSize=5");
+        MockHttpServletResponse response = testUtils.getResource("/v1/node-resources/page?page=1&pageSize=5");
         NodeResources.NodeResourceDtoPage page1 = testUtils.getObject(NodeResources.NodeResourceDtoPage.class,
                 response);
-        assertEquals(5, page1.page.size());
+        assertEquals(5, page1.results.size());
 
-        MockHttpServletResponse response2 = testUtils.getResource("/v1/node-resources/page?page=1&pageSize=5");
+        MockHttpServletResponse response2 = testUtils.getResource("/v1/node-resources/page?page=2&pageSize=5");
         NodeResources.NodeResourceDtoPage page2 = testUtils.getObject(NodeResources.NodeResourceDtoPage.class,
                 response);
-        assertEquals(5, page2.page.size());
+        assertEquals(5, page2.results.size());
 
-        var result = Stream.concat(page1.page.stream(), page2.page.stream()).collect(Collectors.toList());
+        var result = Stream.concat(page1.results.stream(), page2.results.stream()).collect(Collectors.toList());
 
         assertTrue(connections.stream().map(DomainEntity::getPublicId).collect(Collectors.toList())
                 .containsAll(result.stream().map(r -> r.id).collect(Collectors.toList())));
@@ -218,7 +218,6 @@ public class NodeResourcesTest extends RestTest {
                 status().isBadRequest());
         assertEquals(400, response2.getStatus());
     }
-
 
     @Test
     public void can_get_topic_resource() throws Exception {


### PR DESCRIPTION
Endrer navn på liste med treff fra /page endepunkt. Gjør det likt som /search med at tellinga starter på 1 for page.

Heng sammen med https://github.com/NDLANO/backend/pull/140.