### PR TITLE
Reduces dramatically number of queries used to fetch taxonomy-bundle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>11</java.version>
         <springfox.version>3.0.0</springfox.version>
-        <javamelody.version>1.87.0</javamelody.version>
+        <javamelody.version>1.91.0</javamelody.version>
         <testcontainers.version>1.15.3</testcontainers.version>
     </properties>
 

--- a/src/main/java/no/ndla/taxonomy/config/LiquibaseConfig.java
+++ b/src/main/java/no/ndla/taxonomy/config/LiquibaseConfig.java
@@ -54,7 +54,8 @@ public class LiquibaseConfig implements InitializingBean, ResourceLoaderAware {
             this.runOnAllSchemas(dataSource, schemas);
         } catch (SQLException | LiquibaseException exception) {
             // No version table
-            logger.info("Failed to find version table in database. Does not run migration on alternative schemas", exception);
+            logger.info("Failed to find version table in database. Does not run migration on alternative schemas",
+                    exception);
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
@@ -39,20 +39,19 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
     @Query(value = "SELECT nc.id FROM NodeConnection nc ORDER BY nc.id", countQuery = "SELECT count(*) from NodeConnection")
     Page<Integer> findIdsPaginated(Pageable pageable);
 
-    @Query("SELECT nc FROM NodeConnection nc JOIN FETCH nc.parent JOIN FETCH nc.child JOIN FETCH nc.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf LEFT JOIN cvf.customField"
-            + " WHERE nc.id in :ids")
+    @Query("SELECT DISTINCT nc FROM NodeConnection nc " + NODE_CONNECTION_METADATA + " JOIN FETCH nc.parent n "
+            + NODE_METADATA + " JOIN FETCH nc.child c " + CHILD_METADATA + " WHERE nc.id in :ids")
     List<NodeConnection> findByIds(Collection<Integer> ids);
 
-    @Query("SELECT DISTINCT nc FROM NodeConnection nc JOIN FETCH nc.child child JOIN FETCH nc.parent parent"
-            + " JOIN FETCH nc.metadata m LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf"
-            + " LEFT JOIN cvf.customField LEFT JOIN FETCH child.translations WHERE parent.publicId = :publicId")
+    @Query("SELECT DISTINCT nc FROM NodeConnection nc " + NODE_CONNECTION_METADATA + " JOIN FETCH nc.child c "
+            + CHILD_METADATA + " JOIN FETCH nc.parent n" + NODE_METADATA
+            + " LEFT JOIN FETCH c.translations WHERE n.publicId = :publicId")
     List<NodeConnection> findAllByParentPublicIdIncludingChildAndChildTranslations(URI publicId);
 
-    @Query("SELECT DISTINCT nc FROM NodeConnection nc JOIN FETCH nc.parent p JOIN FETCH nc.child c"
-            + " LEFT JOIN p.translations LEFT JOIN FETCH c.translations LEFT JOIN c.cachedPaths"
-            + " JOIN FETCH nc.metadata m LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf"
-            + " LEFT JOIN cvf.customField WHERE nc.child.id IN :nodeId")
+    @Query("SELECT DISTINCT nc FROM NodeConnection nc " + NODE_CONNECTION_METADATA + " JOIN FETCH nc.parent n "
+            + NODE_METADATA + " JOIN FETCH nc.child c" + CHILD_METADATA
+            + " LEFT JOIN n.translations LEFT JOIN FETCH c.translations LEFT JOIN c.cachedPaths"
+            + " WHERE nc.child.id IN :nodeId")
     List<NodeConnection> doFindAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<Integer> nodeId);
 
     default List<NodeConnection> findAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -8,30 +8,44 @@
 package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.NodeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
 public interface NodeRepository extends TaxonomyRepository<Node> {
-    @Query("SELECT DISTINCT n FROM Node n LEFT JOIN FETCH n.cachedPaths JOIN FETCH n.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf LEFT JOIN cvf.customField"
+    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA + " LEFT JOIN FETCH n.cachedPaths"
             + " LEFT JOIN FETCH n.translations WHERE n.context = :context")
     List<Node> findAllByContextIncludingCachedUrlsAndTranslations(boolean context);
 
-    @Query("SELECT DISTINCT n FROM Node n LEFT JOIN FETCH n.cachedPaths JOIN FETCH n.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf LEFT JOIN cvf.customField"
+    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA + " LEFT JOIN FETCH n.cachedPaths"
             + " LEFT JOIN FETCH n.translations WHERE n.publicId = :publicId")
     Optional<Node> findFirstByPublicIdIncludingCachedUrlsAndTranslations(URI publicId);
 
-    @Query("SELECT DISTINCT n FROM Node n LEFT JOIN FETCH n.cachedPaths WHERE n.publicId = :publicId")
+    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA
+            + " LEFT JOIN FETCH n.cachedPaths WHERE n.publicId = :publicId")
     Optional<Node> findFirstByPublicIdIncludingCachedUrls(URI publicId);
 
     Optional<Node> findFirstByPublicId(URI publicId);
 
     @EntityGraph(value = Node.GRAPH, type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT DISTINCT n FROM Node n LEFT JOIN FETCH n.cachedPaths WHERE n.publicId = :publicId")
+    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA
+            + " LEFT JOIN FETCH n.cachedPaths WHERE n.publicId = :publicId")
     Optional<Node> fetchNodeGraphByPublicId(URI publicId);
+
+    @Query(value = "SELECT n.id FROM Node n ORDER BY n.id", countQuery = "SELECT count(*) from Node")
+    Page<Integer> findIdsPaginated(Pageable pageable);
+
+    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA + " LEFT JOIN FETCH n.cachedPaths"
+            + " LEFT JOIN FETCH n.translations WHERE n.id in :ids")
+    List<Node> findByIds(Collection<Integer> ids);
+
+    @Query(value = "SELECT n.id FROM Node n where n.nodeType = :nodeType ORDER BY n.id", countQuery = "SELECT count(*) from Node n where n.nodeType = :nodeType")
+    Page<Integer> findIdsByTypePaginated(Pageable pageable, NodeType nodeType);
 }

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeResourceRepository.java
@@ -16,32 +16,29 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface NodeResourceRepository extends TaxonomyRepository<NodeResource> {
-    @Query("SELECT nr FROM NodeResource nr JOIN FETCH nr.node JOIN FETCH nr.resource JOIN FETCH nr.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf LEFT JOIN cvf.customField")
+    @Query("SELECT nr FROM NodeResource nr " + NODE_RESOURCE_METADATA + " JOIN FETCH nr.node n " + NODE_METADATA
+            + " JOIN FETCH nr.resource r " + RESOURCE_METADATA)
     List<NodeResource> findAllIncludingNodeAndResource();
 
     @Query(value = "SELECT nr.id FROM NodeResource nr ORDER BY nr.id", countQuery = "SELECT count(*) FROM NodeResource")
     Page<Integer> findIdsPaginated(Pageable pageable);
 
-    @Query("SELECT nr FROM NodeResource nr JOIN FETCH nr.node JOIN FETCH nr.resource JOIN FETCH nr.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf LEFT JOIN cvf.customField"
-            + " WHERE nr.id in :ids")
+    @Query("SELECT nr FROM NodeResource nr" + NODE_RESOURCE_METADATA + " JOIN FETCH nr.node n " + NODE_METADATA
+            + " JOIN FETCH nr.resource r " + RESOURCE_METADATA + " WHERE nr.id in :ids")
     List<NodeResource> findByIds(Collection<Integer> ids);
 
-    @Query("SELECT DISTINCT nr FROM NodeResource nr LEFT JOIN FETCH nr.node n LEFT JOIN FETCH nr.resource r"
-            + " JOIN FETCH nr.metadata m LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf"
-            + " LEFT JOIN cvf.customField LEFT JOIN FETCH nr.relevance rel LEFT JOIN FETCH r.resourceTranslations"
+    @Query("SELECT DISTINCT nr FROM NodeResource nr " + NODE_RESOURCE_METADATA + " LEFT JOIN FETCH nr.node n "
+            + NODE_METADATA + " LEFT JOIN FETCH nr.resource r" + RESOURCE_METADATA
             + " LEFT JOIN r.cachedPaths LEFT JOIN FETCH r.resourceResourceTypes rrtFetch"
             + " LEFT JOIN FETCH rrtFetch.resourceType rtFetch LEFT JOIN FETCH rtFetch.resourceTypeTranslations"
             + " WHERE n.id IN :nodeIds")
     List<NodeResource> findAllByNodeIdsIncludingRelationsForResourceDocuments(Collection<Integer> nodeIds);
 
-    @Query("SELECT DISTINCT nr FROM NodeResource nr JOIN FETCH nr.resource r LEFT JOIN FETCH nr.node n"
-            + " JOIN FETCH nr.metadata m LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cvf"
-            + " LEFT JOIN cvf.customField LEFT JOIN nr.relevance rel LEFT JOIN r.resourceResourceTypes rrt"
+    @Query("SELECT DISTINCT nr FROM NodeResource nr " + NODE_RESOURCE_METADATA + " JOIN FETCH nr.resource r "
+            + RESOURCE_METADATA + " LEFT JOIN FETCH nr.node n " + NODE_METADATA
+            + " LEFT JOIN nr.relevance rel LEFT JOIN r.resourceResourceTypes rrt"
             + " LEFT JOIN rrt.resourceType rt LEFT JOIN FETCH r.resourceTranslations LEFT JOIN r.cachedPaths"
             + " LEFT JOIN FETCH r.resourceResourceTypes rrtFetch LEFT JOIN FETCH nr.relevance"
             + " LEFT JOIN FETCH rrtFetch.resourceType rtFetch LEFT JOIN FETCH rtFetch.resourceTypeTranslations"

--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
@@ -8,6 +8,8 @@
 package no.ndla.taxonomy.repositories;
 
 import no.ndla.taxonomy.domain.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
@@ -17,22 +19,21 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ResourceRepository extends TaxonomyRepository<Resource> {
-    @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths JOIN FETCH r.metadata"
+    @Query("SELECT DISTINCT r FROM Resource r " + RESOURCE_METADATA + " LEFT JOIN FETCH r.cachedPaths"
             + " LEFT JOIN FETCH r.resourceTranslations WHERE r.publicId = :publicId")
     Optional<Resource> findFirstByPublicIdIncludingCachedUrlsAndTranslations(URI publicId);
 
     Optional<Resource> findFirstByPublicId(URI publicId);
 
-    @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths JOIN FETCH r.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cfv LEFT JOIN cfv.customField"
+    @Query("SELECT DISTINCT r FROM Resource r " + RESOURCE_METADATA + " LEFT JOIN FETCH r.cachedPaths"
             + " LEFT JOIN FETCH r.resourceTranslations WHERE r.contentUri = :contentUri")
     List<Resource> findByContentUriIncludingCachedUrlsAndTranslations(URI contentUri);
 
-    @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths WHERE r.publicId = :publicId")
+    @Query("SELECT DISTINCT r FROM Resource r " + RESOURCE_METADATA
+            + " LEFT JOIN FETCH r.cachedPaths WHERE r.publicId = :publicId")
     Optional<Resource> findFirstByPublicIdIncludingCachedUrls(URI publicId);
 
-    @Query("SELECT distinct r FROM Resource r LEFT JOIN FETCH r.cachedPaths JOIN FETCH r.metadata m"
-            + " LEFT JOIN m.grepCodes LEFT JOIN FETCH m.customFieldValues cfv LEFT JOIN cfv.customField"
+    @Query("SELECT distinct r FROM Resource r " + RESOURCE_METADATA + " LEFT JOIN FETCH r.cachedPaths"
             + " LEFT JOIN FETCH r.resourceResourceTypes rrt LEFT JOIN FETCH rrt.resourceType rt"
             + " LEFT JOIN FETCH rt.resourceTypeTranslations LEFT JOIN FETCH r.resourceTranslations"
             + " WHERE r.id IN (:idSet)")
@@ -55,4 +56,13 @@ public interface ResourceRepository extends TaxonomyRepository<Resource> {
     @EntityGraph(value = Resource.GRAPH, type = EntityGraph.EntityGraphType.LOAD)
     @Query("SELECT DISTINCT r FROM Resource r LEFT JOIN FETCH r.cachedPaths WHERE r.publicId = :publicId")
     Optional<Resource> fetchResourceGraphByPublicId(URI publicId);
+
+    @Query(value = "SELECT r.id FROM Resource r ORDER BY r.id", countQuery = "SELECT count(*) from Resource")
+    Page<Integer> findIdsPaginated(Pageable pageable);
+
+    @Query("SELECT distinct r FROM Resource r " + RESOURCE_METADATA + " LEFT JOIN FETCH r.cachedPaths"
+            + " LEFT JOIN FETCH r.resourceResourceTypes rrt LEFT JOIN FETCH rrt.resourceType rt"
+            + " LEFT JOIN FETCH rt.resourceTypeTranslations LEFT JOIN FETCH r.resourceTranslations"
+            + " WHERE r.id IN (:ids)")
+    List<Resource> findByIds(Collection<Integer> ids);
 }

--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceResourceTypeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceResourceTypeRepository.java
@@ -14,7 +14,8 @@ import java.net.URI;
 import java.util.List;
 
 public interface ResourceResourceTypeRepository extends TaxonomyRepository<ResourceResourceType> {
-    @Query("SELECT rrt FROM ResourceResourceType rrt JOIN FETCH rrt.resource JOIN FETCH rrt.resourceType")
+    @Query("SELECT rrt FROM ResourceResourceType rrt JOIN FETCH rrt.resource r " + RESOURCE_METADATA
+            + " JOIN FETCH rrt.resourceType")
     List<ResourceResourceType> findAllIncludingResourceAndResourceType();
 
     @Query("SELECT rrt FROM ResourceResourceType rrt JOIN FETCH rrt.resource"

--- a/src/main/java/no/ndla/taxonomy/repositories/TaxonomyRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/TaxonomyRepository.java
@@ -17,6 +17,18 @@ import java.net.URI;
 
 @NoRepositoryBean
 public interface TaxonomyRepository<T> extends JpaRepository<T, Integer>, JpaSpecificationExecutor<T> {
+
+    String RESOURCE_METADATA = " LEFT JOIN FETCH r.metadata rm LEFT JOIN FETCH rm.grepCodes"
+            + " LEFT JOIN FETCH rm.customFieldValues rcfv LEFT JOIN FETCH rcfv.customField ";
+    String NODE_METADATA = " LEFT JOIN FETCH n.metadata nm LEFT JOIN FETCH nm.grepCodes"
+            + " LEFT JOIN FETCH nm.customFieldValues ncfv LEFT JOIN FETCH ncfv.customField ";
+    String CHILD_METADATA = " LEFT JOIN FETCH c.metadata cm LEFT JOIN FETCH cm.grepCodes"
+            + " LEFT JOIN FETCH cm.customFieldValues ccfv LEFT JOIN FETCH ccfv.customField ";
+    String NODE_CONNECTION_METADATA = " LEFT JOIN FETCH nc.metadata ncm LEFT JOIN FETCH ncm.grepCodes"
+            + " LEFT JOIN FETCH ncm.customFieldValues nccfv LEFT JOIN FETCH nccfv.customField ";
+    String NODE_RESOURCE_METADATA = " LEFT JOIN FETCH nr.metadata nrm LEFT JOIN FETCH nrm.grepCodes"
+            + " LEFT JOIN FETCH nrm.customFieldValues nrcfv LEFT JOIN FETCH nrcfv.customField ";
+
     T findByPublicId(URI id);
 
     default T getByPublicId(URI id) {


### PR DESCRIPTION
Adds fetching of metadata to query-definition to avoid additional requests. Went from ~200K to 20K requests'

Ikkje nødvendigvis så fin kode, men ved å spesifisere henting av metadata alle plasser det gjøres tilleggskall, fikk eg redusert antall databasekall dramatisk. Skilte ut strengene for gjenbruk.