### PR TITLE
Gjør publisering av noder raskere ved å sjekke etter endringer.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/DomainObject.java
+++ b/src/main/java/no/ndla/taxonomy/domain/DomainObject.java
@@ -9,8 +9,8 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+import java.util.Collection;
 import java.util.Optional;
-import java.util.Set;
 
 @MappedSuperclass
 public abstract class DomainObject extends DomainEntity {
@@ -27,5 +27,5 @@ public abstract class DomainObject extends DomainEntity {
 
     abstract public Optional<? extends Translation> getTranslation(String languageCode);
 
-    abstract public Set<? extends Translation> getTranslations();
+    abstract public Collection<? extends Translation> getTranslations();
 }

--- a/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
+++ b/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
@@ -9,6 +9,7 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.MappedSuperclass;
 import java.net.URI;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
@@ -40,9 +41,9 @@ public abstract class EntityWithPath extends DomainObject implements EntityWithM
                 .map(CachedPath::getPath).findFirst();
     }
 
-    public abstract Set<EntityWithPathConnection> getParentConnections();
+    public abstract Collection<EntityWithPathConnection> getParentConnections();
 
-    public abstract Set<EntityWithPathConnection> getChildConnections();
+    public abstract Collection<EntityWithPathConnection> getChildConnections();
 
     public Optional<EntityWithPathConnection> getParentConnection() {
         return this.getParentConnections().stream().findFirst();

--- a/src/main/java/no/ndla/taxonomy/domain/Metadata.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Metadata.java
@@ -13,7 +13,9 @@ import org.hibernate.annotations.UpdateTimestamp;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -79,8 +81,8 @@ public class Metadata implements Serializable {
         }
     }
 
-    public Set<GrepCode> getGrepCodes() {
-        return grepCodes.stream().collect(Collectors.toUnmodifiableSet());
+    public Collection<GrepCode> getGrepCodes() {
+        return grepCodes.stream().collect(Collectors.toUnmodifiableList());
     }
 
     public void addCustomFieldValue(CustomFieldValue customFieldValue) {
@@ -94,8 +96,8 @@ public class Metadata implements Serializable {
         this.customFieldValues.remove(customFieldValue);
     }
 
-    public Set<CustomFieldValue> getCustomFieldValues() {
-        return customFieldValues.stream().collect(Collectors.toUnmodifiableSet());
+    public Collection<CustomFieldValue> getCustomFieldValues() {
+        return customFieldValues.stream().collect(Collectors.toUnmodifiableList());
     }
 
     public Integer getId() {
@@ -104,6 +106,14 @@ public class Metadata implements Serializable {
 
     public void setId(Integer id) {
         this.id = id;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
     }
 
     @PreRemove
@@ -115,11 +125,15 @@ public class Metadata implements Serializable {
         }
     }
 
-    public boolean isVisible() {
-        return visible;
-    }
-
-    public void setVisible(boolean visible) {
-        this.visible = visible;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Metadata that = (Metadata) o;
+        return visible == that.visible && Objects.equals(updatedAt, that.updatedAt)
+                && Objects.equals(createdAt, that.createdAt) && Objects.equals(grepCodes, that.grepCodes)
+                && Objects.equals(customFieldValues, that.customFieldValues);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/NodeConnection.java
+++ b/src/main/java/no/ndla/taxonomy/domain/NodeConnection.java
@@ -9,11 +9,13 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
 import java.net.URI;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 @Entity
-public class NodeConnection extends DomainEntity implements EntityWithMetadata, EntityWithPathConnection {
+public class NodeConnection extends DomainEntity
+        implements EntityWithMetadata, EntityWithPathConnection, Comparable<NodeConnection> {
     @ManyToOne
     @JoinColumn(name = "parent_id")
     private Node parent;
@@ -149,5 +151,22 @@ public class NodeConnection extends DomainEntity implements EntityWithMetadata, 
 
     public void setMetadata(Metadata metadata) {
         this.metadata = metadata;
+    }
+
+    @Override
+    public int compareTo(NodeConnection o) {
+        return getPublicId().compareTo(o.getPublicId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NodeConnection that = (NodeConnection) o;
+        return rank == that.rank && parent.getPublicId().equals(that.parent.getPublicId())
+                && child.getPublicId().equals(that.child.getPublicId()) && Objects.equals(relevance, that.relevance)
+                && metadata.equals(that.metadata);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/NodeResource.java
+++ b/src/main/java/no/ndla/taxonomy/domain/NodeResource.java
@@ -9,12 +9,13 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
 import java.net.URI;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
 @Entity
-public class NodeResource extends DomainEntity
-        implements EntityWithMetadata, EntityWithPathConnection, SortableResourceConnection<Node> {
+public class NodeResource extends DomainEntity implements EntityWithMetadata, EntityWithPathConnection,
+        SortableResourceConnection<Node>, Comparable<NodeResource> {
 
     @ManyToOne
     @JoinColumn(name = "node_id")
@@ -156,5 +157,22 @@ public class NodeResource extends DomainEntity
 
     public void setMetadata(Metadata metadata) {
         this.metadata = metadata;
+    }
+
+    @Override
+    public int compareTo(NodeResource o) {
+        return getPublicId().compareTo(o.getPublicId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NodeResource that = (NodeResource) o;
+        return primary == that.primary && rank == that.rank && Objects.equals(node, that.node)
+                && Objects.equals(resource, that.resource) && Objects.equals(relevance, that.relevance)
+                && metadata.equals(that.metadata);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/NodeTranslation.java
+++ b/src/main/java/no/ndla/taxonomy/domain/NodeTranslation.java
@@ -8,9 +8,10 @@
 package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
-public class NodeTranslation implements Translation {
+public class NodeTranslation implements Translation, Comparable<NodeTranslation> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -65,5 +66,23 @@ public class NodeTranslation implements Translation {
 
     public String getLanguageCode() {
         return languageCode;
+    }
+
+    @Override
+    public int compareTo(NodeTranslation o) {
+        if (this.languageCode == null || o.languageCode == null) {
+            return 0;
+        }
+        return this.getLanguageCode().compareTo(o.getLanguageCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        NodeTranslation that = (NodeTranslation) o;
+        return Objects.equals(name, that.name) && Objects.equals(languageCode, that.languageCode);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/Relevance.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Relevance.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 public class Relevance extends DomainObject {
 
     @OneToMany(mappedBy = "relevance", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<RelevanceTranslation> translations = new HashSet<>();
+    private final Set<RelevanceTranslation> translations = new HashSet<>();
 
     public Relevance() {
         setPublicId(URI.create("urn:relevance:" + UUID.randomUUID()));
@@ -37,6 +37,7 @@ public class Relevance extends DomainObject {
         return relevanceTranslation;
     }
 
+    @Override
     public Set<RelevanceTranslation> getTranslations() {
         return translations.stream().collect(Collectors.toUnmodifiableSet());
     }
@@ -67,4 +68,5 @@ public class Relevance extends DomainObject {
     public void removeTranslation(String language) {
         getTranslation(language).ifPresent(this::removeTranslation);
     }
+
 }

--- a/src/main/java/no/ndla/taxonomy/domain/ResourceResourceType.java
+++ b/src/main/java/no/ndla/taxonomy/domain/ResourceResourceType.java
@@ -9,10 +9,11 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
 import java.net.URI;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
-public class ResourceResourceType extends DomainEntity {
+public class ResourceResourceType extends DomainEntity implements Comparable<ResourceResourceType> {
 
     @ManyToOne(cascade = { CascadeType.MERGE })
     @JoinColumn(name = "resource_id")
@@ -73,5 +74,24 @@ public class ResourceResourceType extends DomainEntity {
     @PreRemove
     void preRemove() {
         this.disassociate();
+    }
+
+    @Override
+    public int compareTo(ResourceResourceType o) {
+        if (this.resourceType == null || o.resourceType == null) {
+            return 0;
+        }
+        return this.getResourceType().compareTo(o.getResourceType());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ResourceResourceType that = (ResourceResourceType) o;
+        return Objects.equals(resource.getPublicId(), that.resource.getPublicId())
+                && Objects.equals(resourceType.getPublicId(), that.resourceType.getPublicId());
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/ResourceTranslation.java
+++ b/src/main/java/no/ndla/taxonomy/domain/ResourceTranslation.java
@@ -8,9 +8,10 @@
 package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
-public class ResourceTranslation implements Translation {
+public class ResourceTranslation implements Translation, Comparable<ResourceTranslation> {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Integer id;
@@ -65,5 +66,23 @@ public class ResourceTranslation implements Translation {
 
     public String getLanguageCode() {
         return languageCode;
+    }
+
+    @Override
+    public int compareTo(ResourceTranslation o) {
+        if (this.languageCode == null || o.languageCode == null) {
+            return 0;
+        }
+        return getLanguageCode().compareTo(o.getLanguageCode());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ResourceTranslation that = (ResourceTranslation) o;
+        return Objects.equals(name, that.name) && Objects.equals(languageCode, that.languageCode);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/ResourceType.java
+++ b/src/main/java/no/ndla/taxonomy/domain/ResourceType.java
@@ -9,14 +9,11 @@ package no.ndla.taxonomy.domain;
 
 import javax.persistence.*;
 import java.net.URI;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Entity
-public class ResourceType extends DomainObject {
+public class ResourceType extends DomainObject implements Comparable<ResourceType> {
 
     public ResourceType() {
         setPublicId(URI.create("urn:resourcetype:" + UUID.randomUUID()));
@@ -157,5 +154,23 @@ public class ResourceType extends DomainObject {
         setParent(null);
         new HashSet<>(subtypes).forEach(resourceType -> resourceType.setParent(null));
         new HashSet<>(resourceResourceTypes).forEach(ResourceResourceType::disassociate);
+    }
+
+    @Override
+    public int compareTo(ResourceType o) {
+        return this.getPublicId().compareTo(o.getPublicId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        ResourceType that = (ResourceType) o;
+        return Objects.equals(getPublicId(), that.getPublicId()) && Objects.equals(parent, that.parent)
+                && Objects.equals(subtypes, that.subtypes)
+                && Objects.equals(resourceTypeTranslations, that.resourceTypeTranslations)
+                && Objects.equals(resourceResourceTypes, that.resourceResourceTypes);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/task/NodeUpdater.java
+++ b/src/main/java/no/ndla/taxonomy/service/task/NodeUpdater.java
@@ -93,7 +93,7 @@ public class NodeUpdater extends VersionSchemaUpdater<Node> {
             }
         }
         // Resources
-        Set<NodeResource> nodeResources = new HashSet<>();
+        TreeSet<NodeResource> nodeResources = new TreeSet<>();
         for (NodeResource nodeResource : toSave.getNodeResources()) {
             Resource resource = nodeResource.getResource().get();
             Resource existing = resourceMap.get(resource.getPublicId());
@@ -145,19 +145,23 @@ public class NodeUpdater extends VersionSchemaUpdater<Node> {
             Node node = new Node(toSave);
             updated = nodeRepository.save(node);
         } else {
-            // Node exists, update current
             Node present = existing.get();
-            present.setName(toSave.getName());
-            present.setContentUri(toSave.getContentUri());
-            present.setNodeType(toSave.getNodeType());
-            mergeMetadata(present, toSave.getMetadata());
-            mergeTranslations(present, toSave.getTranslations());
-            updated = nodeRepository.save(present);
+            if (present.equals(toSave)) {
+                updated = present;
+            } else {
+                // Node is changed, update current
+                present.setName(toSave.getName());
+                present.setContentUri(toSave.getContentUri());
+                present.setNodeType(toSave.getNodeType());
+                mergeMetadata(present, toSave.getMetadata());
+                mergeTranslations(present, toSave.getTranslations());
+                updated = nodeRepository.save(present);
+            }
         }
         return updated;
     }
 
-    private void mergeTranslations(Node present, Set<NodeTranslation> translations) {
+    private void mergeTranslations(Node present, Collection<NodeTranslation> translations) {
         Set<NodeTranslation> updated = new HashSet<>();
         for (NodeTranslation translation : translations) {
             Optional<NodeTranslation> t = present.getTranslations().stream()

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
@@ -41,7 +41,7 @@ public class NodeConnectionsTest extends RestTest {
         Node calculus = nodeRepository.getByPublicId(calculusId);
         assertEquals(1, calculus.getChildNodes().size());
         assertAnyTrue(calculus.getChildNodes(), t -> "integration".equals(t.getName()));
-        assertNotNull(nodeConnectionRepository.getByPublicId(id));
+        assertNotNull(connection);
     }
 
     @Test
@@ -319,7 +319,7 @@ public class NodeConnectionsTest extends RestTest {
         Set<String> codes = connection.getMetadata().getGrepCodes().stream().map(GrepCode::getCode)
                 .collect(Collectors.toSet());
         assertTrue(codes.contains("KM123"));
-        Set<CustomFieldValue> customFieldValues = connection.getMetadata().getCustomFieldValues();
+        Collection<CustomFieldValue> customFieldValues = connection.getMetadata().getCustomFieldValues();
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getCustomField).map(CustomField::getKey)
                 .collect(Collectors.toSet()).contains("key"));
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getValue).collect(Collectors.toSet())

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
@@ -199,7 +199,7 @@ public class NodeResourcesTest extends RestTest {
 
         MockHttpServletResponse response2 = testUtils.getResource("/v1/node-resources/page?page=2&pageSize=5");
         NodeResources.NodeResourceDtoPage page2 = testUtils.getObject(NodeResources.NodeResourceDtoPage.class,
-                response);
+                response2);
         assertEquals(5, page2.results.size());
 
         var result = Stream.concat(page1.results.stream(), page2.results.stream()).collect(Collectors.toList());
@@ -445,7 +445,7 @@ public class NodeResourcesTest extends RestTest {
         Set<String> codes = connection.getMetadata().getGrepCodes().stream().map(GrepCode::getCode)
                 .collect(Collectors.toSet());
         assertTrue(codes.contains("KM123"));
-        Set<CustomFieldValue> customFieldValues = connection.getMetadata().getCustomFieldValues();
+        Collection<CustomFieldValue> customFieldValues = connection.getMetadata().getCustomFieldValues();
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getCustomField).map(CustomField::getKey)
                 .collect(Collectors.toSet()).contains("key"));
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getValue).collect(Collectors.toSet())

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodesMetadataTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodesMetadataTest.java
@@ -11,15 +11,14 @@ import no.ndla.taxonomy.domain.CustomField;
 import no.ndla.taxonomy.domain.CustomFieldValue;
 import no.ndla.taxonomy.domain.GrepCode;
 import no.ndla.taxonomy.domain.Node;
-import no.ndla.taxonomy.rest.v1.commands.NodeCommand;
 import no.ndla.taxonomy.service.dtos.MetadataDto;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 import java.net.URI;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -67,7 +66,7 @@ public class NodesMetadataTest extends RestTest {
         Set<String> codes = node.getMetadata().getGrepCodes().stream().map(GrepCode::getCode)
                 .collect(Collectors.toSet());
         assertTrue(codes.contains("KM123"));
-        Set<CustomFieldValue> customFieldValues = node.getMetadata().getCustomFieldValues();
+        Collection<CustomFieldValue> customFieldValues = node.getMetadata().getCustomFieldValues();
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getCustomField).map(CustomField::getKey)
                 .collect(Collectors.toSet()).contains("key"));
         assertTrue(customFieldValues.stream().map(CustomFieldValue::getValue).collect(Collectors.toSet())


### PR DESCRIPTION
Add equals to speed up publishing by dropping unchanged.
Use comparable and collection -> list to make equals work as intended.

set -> collection gjør at vi kan bruke lister og ikkje sets, siden lister er sorterbare. Dette gjør at sammenligning av for eksempel to noder med lister blir korrekt fordi listene kjem i samme rekkefølge.