### PR TITLE
Refactor changelog processing

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -Xmx${HEAPSPACE_MAX:-"1000m"} --add-exports java.desktop/sun.font=ALL-UNNAMED -jar /app.jar
+java -XX:+UseZGC -Xmx${HEAPSPACE_MAX:-"1000m"} --add-exports java.desktop/sun.font=ALL-UNNAMED -jar /app.jar

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -12,22 +12,8 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@NamedEntityGraph(name = Node.GRAPH, includeAllAttributes = true, attributeNodes = {
-        @NamedAttributeNode("translations"), @NamedAttributeNode(value = "metadata"),
-        @NamedAttributeNode(value = "parentConnections", subgraph = "parent-connection"),
-        @NamedAttributeNode(value = "childConnections", subgraph = "child-connection"),
-        @NamedAttributeNode(value = "nodeResources", subgraph = "resource-connections") }, subgraphs = {
-                @NamedSubgraph(name = "parent-connection", attributeNodes = { @NamedAttributeNode("parent"),
-                        @NamedAttributeNode(value = "metadata") }),
-                @NamedSubgraph(name = "child-connection", attributeNodes = { @NamedAttributeNode("child"),
-                        @NamedAttributeNode(value = "metadata") }),
-                @NamedSubgraph(name = "resource-connections", attributeNodes = {
-                        @NamedAttributeNode(value = "metadata"),
-                        @NamedAttributeNode(value = "resource", subgraph = Resource.GRAPH) }) })
 @Entity
 public class Node extends EntityWithPath {
-    public static final String GRAPH = "node-with-connections";
-
     @OneToMany(mappedBy = "child", cascade = CascadeType.ALL, orphanRemoval = true)
     private final Set<NodeConnection> parentConnections = new TreeSet<>();
 

--- a/src/main/java/no/ndla/taxonomy/domain/Resource.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Resource.java
@@ -15,21 +15,8 @@ import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@NamedEntityGraph(name = Resource.GRAPH, includeAllAttributes = true, attributeNodes = {
-        @NamedAttributeNode(value = "metadata"), @NamedAttributeNode(value = "resourceTranslations"),
-        @NamedAttributeNode(value = "resourceResourceTypes", subgraph = "resourceResourceTypes"),
-        @NamedAttributeNode(value = "nodes", subgraph = "node-with-connections") }, subgraphs = {
-                @NamedSubgraph(name = "resourceResourceTypes", attributeNodes = {
-                        @NamedAttributeNode(value = "resourceType", subgraph = "resourceType") }),
-                @NamedSubgraph(name = "resourceType", attributeNodes = {
-                        @NamedAttributeNode("resourceTypeTranslations"),
-                        @NamedAttributeNode(value = "parent", subgraph = "resourceTypeParent") }),
-                @NamedSubgraph(name = "resourceTypeParent", attributeNodes = {
-                        @NamedAttributeNode("resourceTypeTranslations") }) })
 @Entity
 public class Resource extends EntityWithPath {
-    public static final String GRAPH = "resource-with-data";
-
     @Column
     private URI contentUri;
 

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -11,7 +11,6 @@ import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
@@ -33,11 +32,6 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
     Optional<Node> findFirstByPublicIdIncludingCachedUrls(URI publicId);
 
     Optional<Node> findFirstByPublicId(URI publicId);
-
-    @EntityGraph(value = Node.GRAPH, type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT DISTINCT n FROM Node n " + NODE_METADATA + " LEFT JOIN FETCH n.cachedPaths"
-            + " LEFT JOIN FETCH n.translations WHERE n.publicId = :publicId")
-    Node findNodeGraphByPublicId(URI publicId);
 
     @Query(value = "SELECT n.id FROM Node n ORDER BY n.id", countQuery = "SELECT count(*) from Node")
     Page<Integer> findIdsPaginated(Pageable pageable);

--- a/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/ResourceRepository.java
@@ -10,7 +10,6 @@ package no.ndla.taxonomy.repositories;
 import no.ndla.taxonomy.domain.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.Query;
 
 import java.net.URI;
@@ -52,12 +51,6 @@ public interface ResourceRepository extends TaxonomyRepository<Resource> {
     @Query("SELECT r.id FROM Resource r LEFT JOIN r.metadata m LEFT JOIN m.customFieldValues cfv"
             + " LEFT JOIN cfv.customField cf WHERE cfv.value = :value")
     List<Integer> getAllResourceIdsWithMetadataValue(String value);
-
-    @EntityGraph(value = Resource.GRAPH, type = EntityGraph.EntityGraphType.LOAD)
-    @Query("SELECT DISTINCT r FROM Resource r " + RESOURCE_METADATA + " LEFT JOIN FETCH r.cachedPaths"
-            + " LEFT JOIN FETCH r.resourceResourceTypes rrt LEFT JOIN FETCH rrt.resourceType rt"
-            + " WHERE r.publicId = :publicId")
-    Resource findResourceGraphByPublicId(URI publicId);
 
     @Query(value = "SELECT r.id FROM Resource r ORDER BY r.id", countQuery = "SELECT count(*) from Resource")
     Page<Integer> findIdsPaginated(Pageable pageable);

--- a/src/main/java/no/ndla/taxonomy/service/ChangelogService.java
+++ b/src/main/java/no/ndla/taxonomy/service/ChangelogService.java
@@ -7,11 +7,9 @@
 
 package no.ndla.taxonomy.service;
 
-import no.ndla.taxonomy.domain.*;
+import no.ndla.taxonomy.domain.Changelog;
+import no.ndla.taxonomy.domain.DomainEntity;
 import no.ndla.taxonomy.repositories.ChangelogRepository;
-import no.ndla.taxonomy.repositories.ResourceResourceTypeRepository;
-import no.ndla.taxonomy.repositories.ResourceTypeRepository;
-import no.ndla.taxonomy.repositories.TaxonomyRepository;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import no.ndla.taxonomy.service.task.Fetcher;
 import no.ndla.taxonomy.service.task.Updater;
@@ -22,35 +20,26 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.net.URI;
-import java.util.*;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Service
+@Transactional
 public class ChangelogService implements DisposableBean {
     final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final ChangelogRepository changelogRepository;
-    private final CustomFieldService customFieldService;
     private final DomainEntityHelperService domainEntityHelperService;
     private final VersionService versionService;
-    private final ResourceTypeRepository resourceTypeRepository;
-    private final ResourceResourceTypeRepository resourceResourceTypeRepository;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
-    public ChangelogService(ChangelogRepository changelogRepository, CustomFieldService customFieldService,
-            DomainEntityHelperService domainEntityHelperService, VersionService versionService,
-            ResourceTypeRepository resourceTypeRepository,
-            ResourceResourceTypeRepository resourceResourceTypeRepository) {
+    public ChangelogService(ChangelogRepository changelogRepository,
+            DomainEntityHelperService domainEntityHelperService, VersionService versionService) {
         this.changelogRepository = changelogRepository;
-        this.customFieldService = customFieldService;
         this.domainEntityHelperService = domainEntityHelperService;
         this.versionService = versionService;
-        this.resourceTypeRepository = resourceTypeRepository;
-        this.resourceResourceTypeRepository = resourceResourceTypeRepository;
     }
 
     @Transactional
@@ -59,7 +48,7 @@ public class ChangelogService implements DisposableBean {
         changelogRepository.deleteByDoneTrue();
     }
 
-    @Scheduled(fixedRate = 5, timeUnit = TimeUnit.SECONDS)
+    @Scheduled(fixedRate = 2, timeUnit = TimeUnit.SECONDS)
     @Transactional
     public void processChanges() {
         try {
@@ -77,7 +66,6 @@ public class ChangelogService implements DisposableBean {
                     fetcher.setPublicId(changelog.getPublicId());
                     fetcher.setCleanUp(changelog.isCleanUp());
                     fetcher.setDomainEntityHelperService(domainEntityHelperService);
-                    fetcher.setCustomFieldService(customFieldService); // For cleaning metadata
 
                     Future<DomainEntity> future = executor.submit(fetcher);
                     entity = future.get();
@@ -91,7 +79,7 @@ public class ChangelogService implements DisposableBean {
                     updater.setVersion(versionService.schemaFromHash(changelog.getDestinationSchema()));
                     updater.setElement(entity);
                     updater.setCleanUp(changelog.isCleanUp());
-                    updater.setChangelogService(this);
+                    updater.setDomainEntityHelperService(domainEntityHelperService);
 
                     Future<DomainEntity> future = executor.submit(updater);
                     future.get();
@@ -103,315 +91,8 @@ public class ChangelogService implements DisposableBean {
                 changelogRepository.save(changelog);
             }
         } catch (Exception exception) {
+            logger.info("Failed to process entity " + exception.getMessage());
             // Another server have already processed this element
-        }
-
-    }
-
-    @Transactional
-    public Optional<DomainEntity> updateNode(Node node, boolean cleanUp) {
-        Node result;
-        TaxonomyRepository<DomainEntity> repository = domainEntityHelperService.getRepository(node.getPublicId());
-        Node existing = (Node) domainEntityHelperService.getEntityByPublicId(node.getPublicId());
-        if (existing == null) {
-            mergeMetadata(null, node.getMetadata(), node.getPublicId(), cleanUp);
-            result = repository.save(new Node(node));
-        } else if (existing.equals(node)) {
-            result = existing;
-        } else {
-            logger.debug("Updating node " + node.getPublicId());
-            existing.setName(node.getName());
-            existing.setContentUri(node.getContentUri());
-            existing.setNodeType(node.getNodeType());
-            existing.setRoot(node.isRoot());
-            existing.setContext(node.isContext());
-
-            // Translations
-            Set<NodeTranslation> translations = new HashSet<>();
-            for (NodeTranslation nodeTranslation : node.getTranslations()) {
-                Optional<NodeTranslation> existingTranslation = existing.getTranslations().stream()
-                        .filter(translation -> translation.getLanguageCode().equals(nodeTranslation.getLanguageCode()))
-                        .findFirst();
-                if (existingTranslation.isPresent()) {
-                    NodeTranslation tr = existingTranslation.get();
-                    tr.setName(nodeTranslation.getName());
-                    translations.add(tr);
-                } else {
-                    translations.add(new NodeTranslation(nodeTranslation, existing));
-                }
-            }
-            if (!translations.isEmpty()) {
-                existing.clearTranslations();
-                for (NodeTranslation translation : translations) {
-                    existing.addTranslation(translation);
-                }
-            }
-
-            // Metadata
-            mergeMetadata(existing, node.getMetadata(), node.getPublicId(), cleanUp);
-            result = repository.save(existing);
-
-            // delete orphans
-            List<URI> childIds = node.getChildren().stream().map(DomainEntity::getPublicId)
-                    .collect(Collectors.toList());
-            result.getChildren().forEach(nodeConnection -> {
-                if (!childIds.contains(nodeConnection.getPublicId())) {
-                    // Connection deleted
-                    domainEntityHelperService.deleteEntityByPublicId(nodeConnection.getPublicId());
-                }
-            });
-            List<URI> resources = node.getNodeResources().stream().map(DomainEntity::getPublicId)
-                    .collect(Collectors.toList());
-            result.getNodeResources().forEach(nodeResource -> {
-                if (!resources.contains(nodeResource.getPublicId())) {
-                    domainEntityHelperService.deleteEntityByPublicId(nodeResource.getPublicId());
-                }
-            });
-        }
-        if (cleanUp) {
-            domainEntityHelperService.buildPathsForEntity(result.getPublicId());
-        }
-        return Optional.of(result);
-    }
-
-    @Transactional
-    public Optional<DomainEntity> updateResource(Resource resource, boolean cleanUp) {
-        Resource result;
-        TaxonomyRepository<DomainEntity> repository = domainEntityHelperService.getRepository(resource.getPublicId());
-        Resource existing = (Resource) domainEntityHelperService.getEntityByPublicId(resource.getPublicId());
-        resource.getResourceTypes().forEach(this::ensureResourceTypesExists);
-        if (existing == null) {
-            mergeMetadata(null, resource.getMetadata(), resource.getPublicId(), cleanUp);
-            result = repository.save(new Resource(resource, true));
-        } else if (existing.equals(resource)) {
-            logger.debug("Resource " + resource.getPublicId() + " is equal, continue");
-            result = existing;
-        } else {
-            logger.debug("Updating resource " + resource.getPublicId());
-            existing.setName(resource.getName());
-            existing.setContentUri(resource.getContentUri());
-
-            // ResourceTypes
-            Collection<URI> typesToSet = new HashSet<>();
-            Collection<URI> typesToKeep = new HashSet<>();
-            List<URI> existingTypes = existing.getResourceTypes().stream().map(DomainEntity::getPublicId)
-                    .collect(Collectors.toList());
-            resource.getResourceTypes().forEach(resourceType -> {
-                if (existingTypes.contains(resourceType.getPublicId())) {
-                    typesToKeep.add(resourceType.getPublicId());
-                } else {
-                    typesToSet.add(resourceType.getPublicId());
-                }
-            });
-            if (!typesToSet.isEmpty()) {
-                Map<URI, URI> reusedUris = resource.getResourceResourceTypes().stream()
-                        .filter(resourceResourceType -> typesToSet
-                                .contains(resourceResourceType.getResourceType().getPublicId()))
-                        .collect(Collectors.toMap(
-                                resourceResourceType -> resourceResourceType.getResourceType().getPublicId(),
-                                ResourceResourceType::getPublicId));
-
-                Collection<ResourceResourceType> toRemove = new HashSet<>();
-                existing.getResourceResourceTypes().forEach(resourceResourceType -> {
-                    if (!typesToKeep.contains(resourceResourceType.getResourceType().getPublicId())) {
-                        toRemove.add(resourceResourceType);
-                    }
-                });
-                toRemove.forEach(remove -> {
-                    existing.removeResourceResourceType(remove);
-                });
-                typesToSet.forEach(uri -> {
-                    ResourceType resourceType = resourceTypeRepository.findByPublicId(uri);
-                    ResourceResourceType resourceResourceType = existing.addResourceType(resourceType);
-                    if (reusedUris.containsKey(resourceType.getPublicId())) {
-                        resourceResourceType.setPublicId(reusedUris.get(resourceType.getPublicId()));
-                    }
-                });
-            }
-
-            // Translations
-            Set<ResourceTranslation> translations = new HashSet<>();
-            for (ResourceTranslation resourceTranslation : resource.getTranslations()) {
-                Optional<ResourceTranslation> existingTranslation = existing.getTranslations().stream().filter(
-                        translation -> translation.getLanguageCode().equals(resourceTranslation.getLanguageCode()))
-                        .findFirst();
-                if (existingTranslation.isPresent()) {
-                    ResourceTranslation rt = existingTranslation.get();
-                    rt.setName(resourceTranslation.getName());
-                    translations.add(rt);
-                } else {
-                    translations.add(new ResourceTranslation(resourceTranslation, existing));
-                }
-            }
-            if (!translations.isEmpty()) {
-                existing.clearTranslations();
-                for (ResourceTranslation translation : translations) {
-                    existing.addTranslation(translation);
-                }
-            }
-
-            // Metadata
-            mergeMetadata(existing, resource.getMetadata(), resource.getPublicId(), cleanUp);
-            result = repository.save(existing);
-        }
-        if (cleanUp) {
-            domainEntityHelperService.buildPathsForEntity(result.getPublicId());
-        }
-        return Optional.of(result);
-    }
-
-    @Transactional
-    public Optional<DomainEntity> updateNodeConnection(NodeConnection nodeConnection, boolean cleanUp) {
-        NodeConnection result;
-        TaxonomyRepository<DomainEntity> repository = domainEntityHelperService
-                .getRepository(nodeConnection.getPublicId());
-        TaxonomyRepository<DomainEntity> nodeRepository = domainEntityHelperService
-                .getRepository(URI.create("urn:node:dummy"));
-
-        NodeConnection existing = (NodeConnection) domainEntityHelperService
-                .getEntityByPublicId(nodeConnection.getPublicId());
-        if (existing == null) {
-            mergeMetadata(null, nodeConnection.getMetadata(), nodeConnection.getPublicId(), cleanUp);
-            // Use correct objects when copying
-            nodeConnection
-                    .setParent((Node) nodeRepository.findByPublicId(nodeConnection.getParent().get().getPublicId()));
-            nodeConnection
-                    .setChild((Node) nodeRepository.findByPublicId(nodeConnection.getChild().get().getPublicId()));
-            NodeConnection connection = new NodeConnection(nodeConnection);
-            connection.setPublicId(nodeConnection.getPublicId());
-            result = repository.save(connection);
-        } else {
-            /*
-             * if (existing.equals(nodeConnection)) { return Optional.of(existing); }
-             */
-            logger.debug("Updating nodeconnection " + nodeConnection.getPublicId());
-            existing.setParent((Node) nodeRepository.findByPublicId(nodeConnection.getParent().get().getPublicId()));
-            existing.setChild((Node) nodeRepository.findByPublicId(nodeConnection.getChild().get().getPublicId()));
-            existing.setRank(nodeConnection.getRank());
-            if (nodeConnection.getRelevance().isPresent()) {
-                existing.setRelevance(nodeConnection.getRelevance().get());
-            }
-            if (nodeConnection.isPrimary().isPresent()) {
-                existing.setPrimary(nodeConnection.isPrimary().get());
-            }
-
-            mergeMetadata(existing, nodeConnection.getMetadata(), nodeConnection.getPublicId(), cleanUp);
-            result = repository.save(existing);
-        }
-        if (cleanUp) {
-            domainEntityHelperService.buildPathsForEntity(result.getChild().get().getPublicId());
-        }
-        return Optional.of(result);
-    }
-
-    @Transactional
-    public Optional<DomainEntity> updateNodeResource(NodeResource nodeResource, boolean cleanUp) {
-        NodeResource result;
-        TaxonomyRepository<DomainEntity> repository = domainEntityHelperService
-                .getRepository(nodeResource.getPublicId());
-        TaxonomyRepository<DomainEntity> nodeRepository = domainEntityHelperService
-                .getRepository(URI.create("urn:node:dummy"));
-        TaxonomyRepository<DomainEntity> resourceRepository = domainEntityHelperService
-                .getRepository(URI.create("urn:resource:dummy"));
-
-        NodeResource existing = (NodeResource) domainEntityHelperService
-                .getEntityByPublicId(nodeResource.getPublicId());
-        if (existing == null) {
-            mergeMetadata(null, nodeResource.getMetadata(), nodeResource.getPublicId(), cleanUp);
-            // Use correct objects when copying
-            nodeResource.setNode((Node) nodeRepository.findByPublicId(nodeResource.getNode().get().getPublicId()));
-            nodeResource.setResource(
-                    (Resource) resourceRepository.findByPublicId(nodeResource.getResource().get().getPublicId()));
-            NodeResource connection = new NodeResource(nodeResource);
-            result = repository.save(connection);
-        } else {
-            /*
-             * if (existing.equals(nodeResource)) { return Optional.of(existing); }
-             */
-            logger.debug("Updating noderesource " + nodeResource.getPublicId());
-            existing.setNode((Node) nodeRepository.findByPublicId(nodeResource.getNode().get().getPublicId()));
-            existing.setResource(
-                    (Resource) resourceRepository.findByPublicId(nodeResource.getResource().get().getPublicId()));
-            existing.setRank(nodeResource.getRank());
-            if (nodeResource.getRelevance().isPresent()) {
-                existing.setRelevance(nodeResource.getRelevance().get());
-            }
-            if (nodeResource.isPrimary().isPresent()) {
-                existing.setPrimary(nodeResource.isPrimary().get());
-            }
-            mergeMetadata(existing, nodeResource.getMetadata(), nodeResource.getPublicId(), cleanUp);
-            result = repository.save(existing);
-        }
-        if (cleanUp) {
-            domainEntityHelperService.buildPathsForEntity(result.getResource().get().getPublicId());
-        }
-        return Optional.of(result);
-    }
-
-    private ResourceType ensureResourceTypesExists(ResourceType resourceType) {
-        ResourceType parent = null;
-        if (resourceType.getParent().isPresent()) {
-            parent = ensureResourceTypesExists(resourceType.getParent().get());
-        }
-        Optional<ResourceType> existing = resourceTypeRepository
-                .findFirstByPublicIdIncludingTranslations(resourceType.getPublicId());
-        if (existing.isEmpty()) {
-            // Create resource type
-            ResourceType rt = new ResourceType(resourceType, parent);
-            return resourceTypeRepository.save(rt);
-        }
-        return existing.get();
-    }
-
-    protected void mergeMetadata(EntityWithMetadata present, Metadata metadata, URI publicId, boolean cleanUp) {
-        if (present == null) {
-            // Make sure custom fields exists
-            metadata.getCustomFieldValues().forEach(customFieldValue -> customFieldService.setCustomField(null,
-                    customFieldValue.getCustomField().getKey(), null));
-            return;
-        }
-        Metadata presentMetadata = present.getMetadata();
-        if (presentMetadata.equals(metadata)) {
-            // All ok, do nothing
-            return;
-        }
-
-        presentMetadata.setVisible(metadata.isVisible());
-        for (GrepCode grepCode : metadata.getGrepCodes()) {
-            if (!presentMetadata.getGrepCodes().stream().map(GrepCode::getCode).collect(Collectors.toList())
-                    .contains(grepCode.getCode())) {
-                presentMetadata.addGrepCode(new GrepCode(grepCode, presentMetadata));
-            }
-        }
-        if (!cleanUp) {
-            List<String> existingKeys = presentMetadata.getCustomFieldValues().stream()
-                    .map(customFieldValue1 -> customFieldValue1.getCustomField().getKey()).collect(Collectors.toList());
-            metadata.getCustomFieldValues().forEach(customFieldValue -> {
-                String key = customFieldValue.getCustomField().getKey();
-                if (!List.of(CustomField.IS_PUBLISHING, CustomField.IS_CHANGED, CustomField.REQUEST_PUBLISH)
-                        .contains(key)) {
-                    if (!existingKeys.contains(key)) {
-                        customFieldService.setCustomField(presentMetadata, key, customFieldValue.getValue());
-                    } else {
-                        // Update customfield
-                        Optional<CustomFieldValue> value = presentMetadata.getCustomFieldValueByKey(key);
-                        value.ifPresent(fieldValue -> fieldValue.setValue(customFieldValue.getValue()));
-                    }
-                }
-            });
-        } else {
-            logger.debug("Cleaning metadata in updater");
-            presentMetadata.getCustomFieldValues().forEach(customFieldValue -> {
-                String key = customFieldValue.getCustomField().getKey();
-                // Remove specially handled fields
-                if (Arrays.asList(CustomField.IS_PUBLISHING, CustomField.IS_CHANGED, CustomField.REQUEST_PUBLISH)
-                        .contains(key)) {
-                    presentMetadata.removeCustomFieldValue(customFieldValue);
-                    if (key.equals(CustomField.IS_PUBLISHING)) {
-                        logger.info(String.format("Publishing of node %s finished", publicId));
-                    }
-                }
-            });
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperService.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperService.java
@@ -12,6 +12,7 @@ import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.repositories.TaxonomyRepository;
 
 import java.net.URI;
+import java.util.Optional;
 
 public interface DomainEntityHelperService {
     Node getNodeByPublicId(URI publicId);
@@ -23,4 +24,8 @@ public interface DomainEntityHelperService {
     void buildPathsForEntity(URI publicId);
 
     void deleteEntityByPublicId(URI publicId);
+
+    Optional<DomainEntity> getProcessedEntityByPublicId(URI publicId, boolean addIsPublishing, boolean cleanUp);
+
+    Optional<DomainEntity> updateEntity(DomainEntity domainEntity, boolean cleanUp);
 }

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
@@ -9,31 +9,41 @@ package no.ndla.taxonomy.service;
 
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.repositories.*;
+import no.ndla.taxonomy.service.exceptions.EntityNotFoundException;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URI;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 @Transactional(readOnly = true)
 public class DomainEntityHelperServiceImpl implements DomainEntityHelperService {
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final NodeRepository nodeRepository;
     private final ResourceRepository resourceRepository;
     private final NodeConnectionRepository nodeConnectionRepository;
     private final NodeResourceRepository nodeResourceRepository;
+    private final ResourceTypeRepository resourceTypeRepository;
     private final CachedUrlUpdaterService cachedUrlUpdaterService;
+    private final CustomFieldService customFieldService;
 
     public DomainEntityHelperServiceImpl(NodeRepository nodeRepository, ResourceRepository resourceRepository,
             NodeConnectionRepository nodeConnectionRepository, NodeResourceRepository nodeResourceRepository,
-            CachedUrlUpdaterService cachedUrlUpdaterService) {
+            ResourceTypeRepository resourceTypeRepository, CachedUrlUpdaterService cachedUrlUpdaterService,
+            CustomFieldService customFieldService) {
         this.nodeRepository = nodeRepository;
         this.resourceRepository = resourceRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
         this.nodeResourceRepository = nodeResourceRepository;
+        this.resourceTypeRepository = resourceTypeRepository;
         this.cachedUrlUpdaterService = cachedUrlUpdaterService;
+        this.customFieldService = customFieldService;
     }
 
     @Override
@@ -44,7 +54,7 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.MANDATORY)
     public DomainEntity getEntityByPublicId(URI publicId) {
         switch (publicId.getSchemeSpecificPart().split(":")[0]) {
         case "subject":
@@ -98,5 +108,359 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
     public void deleteEntityByPublicId(URI publicId) {
         TaxonomyRepository repository = getRepository(publicId);
         repository.deleteByPublicId(publicId);
+    }
+
+    @Override
+    @Transactional
+    public Optional<DomainEntity> getProcessedEntityByPublicId(URI publicId, boolean addIsPublishing, boolean cleanUp) {
+        DomainEntity entity = getEntityByPublicId(publicId);
+        if (entity instanceof EntityWithMetadata) {
+            EntityWithMetadata entityWithMetadata = (EntityWithMetadata) entity;
+            if (addIsPublishing && !cleanUp) {
+                if (!entityWithMetadata.getMetadata().getCustomFieldValues().stream()
+                        .map(customFieldValue -> customFieldValue.getCustomField().getKey())
+                        .collect(Collectors.toList()).contains(CustomField.IS_PUBLISHING)) {
+                    customFieldService.setCustomField(entityWithMetadata.getMetadata(), CustomField.IS_PUBLISHING,
+                            "true");
+                }
+                return Optional.of(entity);
+            }
+            if (cleanUp) {
+                Metadata metadata = entityWithMetadata.getMetadata();
+                unsetCustomField(metadata, CustomField.IS_PUBLISHING);
+                unsetCustomField(metadata, CustomField.REQUEST_PUBLISH);
+                unsetCustomField(metadata, CustomField.IS_CHANGED);
+            }
+        }
+        return Optional.ofNullable(entity);
+    }
+
+    private void unsetCustomField(Metadata metadata, String customfield) {
+        metadata.getCustomFieldValues().forEach(customFieldValue -> {
+            if (customFieldValue.getCustomField().getKey().equals(customfield)) {
+                try {
+                    customFieldService.unsetCustomField(customFieldValue.getId());
+                } catch (EntityNotFoundException e) {
+                    // Already deleted. Do nothing.
+                }
+            }
+        });
+    }
+
+    @Override
+    @Transactional
+    public Optional<DomainEntity> updateEntity(DomainEntity domainEntity, boolean cleanUp) {
+        if (domainEntity instanceof Node) {
+            return updateNode((Node) domainEntity, cleanUp);
+        }
+        if (domainEntity instanceof Resource) {
+            return updateResource((Resource) domainEntity, cleanUp);
+        }
+        if (domainEntity instanceof NodeConnection) {
+            return updateNodeConnection((NodeConnection) domainEntity, cleanUp);
+        }
+        if (domainEntity instanceof NodeResource) {
+            return updateNodeResource((NodeResource) domainEntity, cleanUp);
+        }
+        throw new IllegalArgumentException("Wrong type of element to update: " + domainEntity.getEntityName());
+
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    private Optional<DomainEntity> updateNode(Node node, boolean cleanUp) {
+        Node result;
+        TaxonomyRepository<DomainEntity> repository = getRepository(node.getPublicId());
+        Node existing = (Node) getEntityByPublicId(node.getPublicId());
+        if (existing == null) {
+            mergeMetadata(null, node.getMetadata(), node.getPublicId(), cleanUp);
+            result = repository.save(new Node(node));
+        } else if (existing.equals(node)) {
+            result = existing;
+        } else {
+            logger.debug("Updating node " + node.getPublicId());
+            existing.setName(node.getName());
+            existing.setContentUri(node.getContentUri());
+            existing.setNodeType(node.getNodeType());
+            existing.setRoot(node.isRoot());
+            existing.setContext(node.isContext());
+
+            // Translations
+            Set<NodeTranslation> translations = new HashSet<>();
+            for (NodeTranslation nodeTranslation : node.getTranslations()) {
+                Optional<NodeTranslation> existingTranslation = existing.getTranslations().stream()
+                        .filter(translation -> translation.getLanguageCode().equals(nodeTranslation.getLanguageCode()))
+                        .findFirst();
+                if (existingTranslation.isPresent()) {
+                    NodeTranslation tr = existingTranslation.get();
+                    tr.setName(nodeTranslation.getName());
+                    translations.add(tr);
+                } else {
+                    translations.add(new NodeTranslation(nodeTranslation, existing));
+                }
+            }
+            if (!translations.isEmpty()) {
+                existing.clearTranslations();
+                for (NodeTranslation translation : translations) {
+                    existing.addTranslation(translation);
+                }
+            }
+
+            // Metadata
+            mergeMetadata(existing, node.getMetadata(), node.getPublicId(), cleanUp);
+            result = repository.save(existing);
+
+            // delete orphans
+            List<URI> childIds = node.getChildren().stream().map(DomainEntity::getPublicId)
+                    .collect(Collectors.toList());
+            result.getChildren().forEach(nodeConnection -> {
+                if (!childIds.contains(nodeConnection.getPublicId())) {
+                    // Connection deleted
+                    deleteEntityByPublicId(nodeConnection.getPublicId());
+                }
+            });
+            List<URI> resources = node.getNodeResources().stream().map(DomainEntity::getPublicId)
+                    .collect(Collectors.toList());
+            result.getNodeResources().forEach(nodeResource -> {
+                if (!resources.contains(nodeResource.getPublicId())) {
+                    deleteEntityByPublicId(nodeResource.getPublicId());
+                }
+            });
+        }
+        if (cleanUp) {
+            buildPathsForEntity(result.getPublicId());
+        }
+        return Optional.of(result);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    private Optional<DomainEntity> updateResource(Resource resource, boolean cleanUp) {
+        Resource result;
+        TaxonomyRepository<DomainEntity> repository = getRepository(resource.getPublicId());
+        Resource existing = (Resource) getEntityByPublicId(resource.getPublicId());
+        resource.getResourceTypes().forEach(this::ensureResourceTypesExists);
+        if (existing == null) {
+            mergeMetadata(null, resource.getMetadata(), resource.getPublicId(), cleanUp);
+            result = repository.save(new Resource(resource, true));
+        } else if (existing.equals(resource)) {
+            logger.debug("Resource " + resource.getPublicId() + " is equal, continue");
+            result = existing;
+        } else {
+            logger.debug("Updating resource " + resource.getPublicId());
+            existing.setName(resource.getName());
+            existing.setContentUri(resource.getContentUri());
+
+            // ResourceTypes
+            Collection<URI> typesToSet = new HashSet<>();
+            Collection<URI> typesToKeep = new HashSet<>();
+            List<URI> existingTypes = existing.getResourceTypes().stream().map(DomainEntity::getPublicId)
+                    .collect(Collectors.toList());
+            resource.getResourceTypes().forEach(resourceType -> {
+                if (existingTypes.contains(resourceType.getPublicId())) {
+                    typesToKeep.add(resourceType.getPublicId());
+                } else {
+                    typesToSet.add(resourceType.getPublicId());
+                }
+            });
+            if (!typesToSet.isEmpty()) {
+                Map<URI, URI> reusedUris = resource.getResourceResourceTypes().stream()
+                        .filter(resourceResourceType -> typesToSet
+                                .contains(resourceResourceType.getResourceType().getPublicId()))
+                        .collect(Collectors.toMap(
+                                resourceResourceType -> resourceResourceType.getResourceType().getPublicId(),
+                                ResourceResourceType::getPublicId));
+
+                Collection<ResourceResourceType> toRemove = new HashSet<>();
+                existing.getResourceResourceTypes().forEach(resourceResourceType -> {
+                    if (!typesToKeep.contains(resourceResourceType.getResourceType().getPublicId())) {
+                        toRemove.add(resourceResourceType);
+                    }
+                });
+                toRemove.forEach(existing::removeResourceResourceType);
+                typesToSet.forEach(uri -> {
+                    ResourceType resourceType = resourceTypeRepository.findByPublicId(uri);
+                    ResourceResourceType resourceResourceType = existing.addResourceType(resourceType);
+                    if (reusedUris.containsKey(resourceType.getPublicId())) {
+                        resourceResourceType.setPublicId(reusedUris.get(resourceType.getPublicId()));
+                    }
+                });
+            }
+
+            // Translations
+            Set<ResourceTranslation> translations = new HashSet<>();
+            for (ResourceTranslation resourceTranslation : resource.getTranslations()) {
+                Optional<ResourceTranslation> existingTranslation = existing.getTranslations().stream().filter(
+                        translation -> translation.getLanguageCode().equals(resourceTranslation.getLanguageCode()))
+                        .findFirst();
+                if (existingTranslation.isPresent()) {
+                    ResourceTranslation rt = existingTranslation.get();
+                    rt.setName(resourceTranslation.getName());
+                    translations.add(rt);
+                } else {
+                    translations.add(new ResourceTranslation(resourceTranslation, existing));
+                }
+            }
+            if (!translations.isEmpty()) {
+                existing.clearTranslations();
+                for (ResourceTranslation translation : translations) {
+                    existing.addTranslation(translation);
+                }
+            }
+
+            // Metadata
+            mergeMetadata(existing, resource.getMetadata(), resource.getPublicId(), cleanUp);
+            result = repository.save(existing);
+        }
+        if (cleanUp) {
+            buildPathsForEntity(result.getPublicId());
+        }
+        return Optional.of(result);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    private Optional<DomainEntity> updateNodeConnection(NodeConnection nodeConnection, boolean cleanUp) {
+        NodeConnection result;
+        TaxonomyRepository<DomainEntity> repository = getRepository(nodeConnection.getPublicId());
+        TaxonomyRepository<DomainEntity> nodeRepository = getRepository(URI.create("urn:node:dummy"));
+
+        NodeConnection existing = (NodeConnection) getEntityByPublicId(nodeConnection.getPublicId());
+        if (existing == null) {
+            mergeMetadata(null, nodeConnection.getMetadata(), nodeConnection.getPublicId(), cleanUp);
+            // Use correct objects when copying
+            nodeConnection
+                    .setParent((Node) nodeRepository.findByPublicId(nodeConnection.getParent().get().getPublicId()));
+            nodeConnection
+                    .setChild((Node) nodeRepository.findByPublicId(nodeConnection.getChild().get().getPublicId()));
+            NodeConnection connection = new NodeConnection(nodeConnection);
+            connection.setPublicId(nodeConnection.getPublicId());
+            result = repository.save(connection);
+        } else {
+            /*
+             * if (existing.equals(nodeConnection)) { return Optional.of(existing); }
+             */
+            logger.debug("Updating nodeconnection " + nodeConnection.getPublicId());
+            existing.setParent((Node) nodeRepository.findByPublicId(nodeConnection.getParent().get().getPublicId()));
+            existing.setChild((Node) nodeRepository.findByPublicId(nodeConnection.getChild().get().getPublicId()));
+            existing.setRank(nodeConnection.getRank());
+            if (nodeConnection.getRelevance().isPresent()) {
+                existing.setRelevance(nodeConnection.getRelevance().get());
+            }
+            if (nodeConnection.isPrimary().isPresent()) {
+                existing.setPrimary(nodeConnection.isPrimary().get());
+            }
+
+            mergeMetadata(existing, nodeConnection.getMetadata(), nodeConnection.getPublicId(), cleanUp);
+            result = repository.save(existing);
+        }
+        if (cleanUp) {
+            buildPathsForEntity(result.getChild().get().getPublicId());
+        }
+        return Optional.of(result);
+    }
+
+    @Transactional(propagation = Propagation.MANDATORY)
+    private Optional<DomainEntity> updateNodeResource(NodeResource nodeResource, boolean cleanUp) {
+        NodeResource result;
+        TaxonomyRepository<DomainEntity> repository = getRepository(nodeResource.getPublicId());
+        TaxonomyRepository<DomainEntity> nodeRepository = getRepository(URI.create("urn:node:dummy"));
+        TaxonomyRepository<DomainEntity> resourceRepository = getRepository(URI.create("urn:resource:dummy"));
+
+        NodeResource existing = (NodeResource) getEntityByPublicId(nodeResource.getPublicId());
+        if (existing == null) {
+            mergeMetadata(null, nodeResource.getMetadata(), nodeResource.getPublicId(), cleanUp);
+            // Use correct objects when copying
+            nodeResource.setNode((Node) nodeRepository.findByPublicId(nodeResource.getNode().get().getPublicId()));
+            nodeResource.setResource(
+                    (Resource) resourceRepository.findByPublicId(nodeResource.getResource().get().getPublicId()));
+            NodeResource connection = new NodeResource(nodeResource);
+            result = repository.save(connection);
+        } else {
+            /*
+             * if (existing.equals(nodeResource)) { return Optional.of(existing); }
+             */
+            logger.debug("Updating noderesource " + nodeResource.getPublicId());
+            existing.setNode((Node) nodeRepository.findByPublicId(nodeResource.getNode().get().getPublicId()));
+            existing.setResource(
+                    (Resource) resourceRepository.findByPublicId(nodeResource.getResource().get().getPublicId()));
+            existing.setRank(nodeResource.getRank());
+            if (nodeResource.getRelevance().isPresent()) {
+                existing.setRelevance(nodeResource.getRelevance().get());
+            }
+            if (nodeResource.isPrimary().isPresent()) {
+                existing.setPrimary(nodeResource.isPrimary().get());
+            }
+            mergeMetadata(existing, nodeResource.getMetadata(), nodeResource.getPublicId(), cleanUp);
+            result = repository.save(existing);
+        }
+        if (cleanUp) {
+            buildPathsForEntity(result.getResource().get().getPublicId());
+        }
+        return Optional.of(result);
+    }
+
+    private ResourceType ensureResourceTypesExists(ResourceType resourceType) {
+        ResourceType parent = null;
+        if (resourceType.getParent().isPresent()) {
+            parent = ensureResourceTypesExists(resourceType.getParent().get());
+        }
+        Optional<ResourceType> existing = resourceTypeRepository
+                .findFirstByPublicIdIncludingTranslations(resourceType.getPublicId());
+        if (existing.isEmpty()) {
+            // Create resource type
+            ResourceType rt = new ResourceType(resourceType, parent);
+            return resourceTypeRepository.save(rt);
+        }
+        return existing.get();
+    }
+
+    protected void mergeMetadata(EntityWithMetadata present, Metadata metadata, URI publicId, boolean cleanUp) {
+        if (present == null) {
+            // Make sure custom fields exists
+            metadata.getCustomFieldValues().forEach(customFieldValue -> customFieldService.setCustomField(null,
+                    customFieldValue.getCustomField().getKey(), null));
+            return;
+        }
+        Metadata presentMetadata = present.getMetadata();
+        if (presentMetadata.equals(metadata)) {
+            // All ok, do nothing
+            return;
+        }
+
+        presentMetadata.setVisible(metadata.isVisible());
+        for (GrepCode grepCode : metadata.getGrepCodes()) {
+            if (!presentMetadata.getGrepCodes().stream().map(GrepCode::getCode).collect(Collectors.toList())
+                    .contains(grepCode.getCode())) {
+                presentMetadata.addGrepCode(new GrepCode(grepCode, presentMetadata));
+            }
+        }
+        if (!cleanUp) {
+            List<String> existingKeys = presentMetadata.getCustomFieldValues().stream()
+                    .map(customFieldValue1 -> customFieldValue1.getCustomField().getKey()).collect(Collectors.toList());
+            metadata.getCustomFieldValues().forEach(customFieldValue -> {
+                String key = customFieldValue.getCustomField().getKey();
+                if (!List.of(CustomField.IS_PUBLISHING, CustomField.IS_CHANGED, CustomField.REQUEST_PUBLISH)
+                        .contains(key)) {
+                    if (!existingKeys.contains(key)) {
+                        customFieldService.setCustomField(presentMetadata, key, customFieldValue.getValue());
+                    } else {
+                        // Update customfield
+                        Optional<CustomFieldValue> value = presentMetadata.getCustomFieldValueByKey(key);
+                        value.ifPresent(fieldValue -> fieldValue.setValue(customFieldValue.getValue()));
+                    }
+                }
+            });
+        } else {
+            logger.debug("Cleaning metadata in updater");
+            presentMetadata.getCustomFieldValues().forEach(customFieldValue -> {
+                String key = customFieldValue.getCustomField().getKey();
+                // Remove specially handled fields
+                if (Arrays.asList(CustomField.IS_PUBLISHING, CustomField.IS_CHANGED, CustomField.REQUEST_PUBLISH)
+                        .contains(key)) {
+                    presentMetadata.removeCustomFieldValue(customFieldValue);
+                    if (key.equals(CustomField.IS_PUBLISHING)) {
+                        logger.info(String.format("Publishing of node %s finished", publicId));
+                    }
+                }
+            });
+        }
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImpl.java
@@ -147,13 +147,17 @@ public class DomainEntityHelperServiceImpl implements DomainEntityHelperService 
             ((Resource) domainEntity).getTranslations().forEach(ResourceTranslation::getName);
             ((Resource) domainEntity).getParentConnections();
             ((Resource) domainEntity).getResourceResourceTypes();
-            ((Resource) domainEntity).getResourceTypes().forEach(ResourceType::getTranslations);
+            ((Resource) domainEntity).getResourceResourceTypes().forEach(ResourceResourceType::getResourceType);
+            ((Resource) domainEntity).getResourceTypes().forEach(this::initializeFields);
         } else if (domainEntity instanceof NodeConnection) {
             ((NodeConnection) domainEntity).getParent().ifPresent(this::initializeFields);
             ((NodeConnection) domainEntity).getChild().ifPresent(this::initializeFields);
         } else if (domainEntity instanceof NodeResource) {
             ((NodeResource) domainEntity).getNode().ifPresent(this::initializeFields);
             ((NodeResource) domainEntity).getResource().ifPresent(this::initializeFields);
+        } else if (domainEntity instanceof ResourceType) {
+            ((ResourceType) domainEntity).getParent().ifPresent(this::initializeFields);
+            ((ResourceType) domainEntity).getTranslations().forEach(ResourceTypeTranslation::getName);
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -43,11 +43,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
     private final EntityConnectionService connectionService;
     private final VersionService versionService;
     private final TreeSorter topicTreeSorter;
-    private final CachedUrlUpdaterService cachedUrlUpdaterService;
-
     private final ChangelogRepository changelogRepository;
     private final DomainEntityHelperService domainEntityHelperService;
-    private final CustomFieldService customFieldService;
 
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
@@ -58,17 +55,14 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
 
     public NodeService(NodeRepository nodeRepository, NodeConnectionRepository nodeConnectionRepository,
             EntityConnectionService connectionService, VersionService versionService, TreeSorter topicTreeSorter,
-            CachedUrlUpdaterService cachedUrlUpdaterService, ChangelogRepository changelogRepository,
-            DomainEntityHelperService domainEntityHelperService, CustomFieldService customFieldService) {
+            ChangelogRepository changelogRepository, DomainEntityHelperService domainEntityHelperService) {
         this.nodeRepository = nodeRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
         this.connectionService = connectionService;
         this.versionService = versionService;
         this.topicTreeSorter = topicTreeSorter;
-        this.cachedUrlUpdaterService = cachedUrlUpdaterService;
         this.changelogRepository = changelogRepository;
         this.domainEntityHelperService = domainEntityHelperService;
-        this.customFieldService = customFieldService;
     }
 
     @Transactional
@@ -188,13 +182,6 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
     }
 
     @Transactional
-    public Node updatePaths(Node node) {
-        Node saved = nodeRepository.save(node);
-        cachedUrlUpdaterService.updateCachedUrls(saved);
-        return saved;
-    }
-
-    @Transactional
     public boolean makeAllResourcesPrimary(URI nodePublicId, boolean recursive) {
         final var node = nodeRepository.findFirstByPublicId(nodePublicId)
                 .orElseThrow(() -> new NotFoundServiceException("Node was not found"));
@@ -233,7 +220,6 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
         try {
             Fetcher fetcher = new Fetcher();
             fetcher.setDomainEntityHelperService(domainEntityHelperService);
-            fetcher.setCustomFieldService(customFieldService);
             fetcher.setVersion(versionService.schemaFromHash(source));
             fetcher.setPublicId(nodeId);
             fetcher.setAddIsPublishing(isRoot);

--- a/src/main/java/no/ndla/taxonomy/service/task/Updater.java
+++ b/src/main/java/no/ndla/taxonomy/service/task/Updater.java
@@ -9,15 +9,16 @@ package no.ndla.taxonomy.service.task;
 
 import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.service.ChangelogService;
+import no.ndla.taxonomy.service.DomainEntityHelperService;
 
 import java.util.Optional;
 
 public class Updater extends Task<DomainEntity> {
-    private ChangelogService changelogService;
+    private DomainEntityHelperService domainEntityHelperService;
     private DomainEntity element;
 
-    public void setChangelogService(ChangelogService changelogService) {
-        this.changelogService = changelogService;
+    public void setDomainEntityHelperService(DomainEntityHelperService domainEntityHelperService) {
+        this.domainEntityHelperService = domainEntityHelperService;
     }
 
     public void setElement(DomainEntity element) {
@@ -30,19 +31,7 @@ public class Updater extends Task<DomainEntity> {
 
     @Override
     protected Optional<DomainEntity> execute() {
-        if (element instanceof Node) {
-            return changelogService.updateNode((Node) element, this.cleanUp);
-        }
-        if (element instanceof Resource) {
-            return changelogService.updateResource((Resource) element, this.cleanUp);
-        }
-        if (element instanceof NodeConnection) {
-            return changelogService.updateNodeConnection((NodeConnection) element, this.cleanUp);
-        }
-        if (element instanceof NodeResource) {
-            return changelogService.updateNodeResource((NodeResource) element, this.cleanUp);
-        }
-        throw new IllegalArgumentException("Wrong type of element to update: " + element.getEntityName());
+        return domainEntityHelperService.updateEntity(element, this.cleanUp);
     }
 
 }

--- a/src/test/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/DomainEntityHelperServiceImplTest.java
@@ -10,10 +10,7 @@ package no.ndla.taxonomy.service;
 import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeType;
 import no.ndla.taxonomy.domain.Resource;
-import no.ndla.taxonomy.repositories.NodeConnectionRepository;
-import no.ndla.taxonomy.repositories.NodeRepository;
-import no.ndla.taxonomy.repositories.NodeResourceRepository;
-import no.ndla.taxonomy.repositories.ResourceRepository;
+import no.ndla.taxonomy.repositories.*;
 import no.ndla.taxonomy.service.exceptions.NotFoundServiceException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,9 +45,11 @@ class DomainEntityHelperServiceImplTest {
     void setUp(@Autowired NodeRepository nodeRepository, @Autowired ResourceRepository resourceRepository,
             @Autowired NodeConnectionRepository nodeConnectionRepository,
             @Autowired NodeResourceRepository nodeResourceRepository,
-            @Autowired CachedUrlUpdaterService cachedUrlUpdaterService) {
+            @Autowired ResourceTypeRepository resourceTypeRepository,
+            @Autowired CachedUrlUpdaterService cachedUrlUpdaterService,
+            @Autowired CustomFieldService customFieldService) {
         service = new DomainEntityHelperServiceImpl(nodeRepository, resourceRepository, nodeConnectionRepository,
-                nodeResourceRepository, cachedUrlUpdaterService);
+                nodeResourceRepository, resourceTypeRepository, cachedUrlUpdaterService, customFieldService);
 
         topic1 = new Node(NodeType.TOPIC);
         topic1.setPublicId(URI.create("urn:topic:test:1"));

--- a/src/test/java/no/ndla/taxonomy/service/NodePublishingIntegrationTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodePublishingIntegrationTest.java
@@ -47,9 +47,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
     ResourceRepository resourceRepository;
 
     @Autowired
-    ResourceTypeRepository resourceTypeRepository;
-
-    @Autowired
     NodeResourceRepository nodeResourceRepository;
 
     @Autowired
@@ -71,7 +68,10 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
     Builder builder;
 
     @Autowired
-    private ThreadPoolTaskExecutor executor;
+    DomainEntityHelperService domainEntityHelperService;
+
+    @Autowired
+    ThreadPoolTaskExecutor executor;
 
     @BeforeEach
     void clearAllRepos() {
@@ -168,7 +168,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Node published = nodeRepository.findNodeGraphByPublicId(node.getPublicId());
+        Node published = (Node) domainEntityHelperService.getProcessedEntityByPublicId(node.getPublicId(), false, false)
+                .get();
         Resource connected = published.getNodeResources().stream().findFirst().get().getResource().get();
         Resource resource = resourceRepository
                 .findFirstByPublicIdIncludingCachedUrlsAndTranslations(connected.getPublicId()).get();
@@ -256,9 +257,12 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Resource resource = resourceRepository.findResourceGraphByPublicId(URI.create("urn:resource:1"));
-        Node subnode = nodeRepository.findNodeGraphByPublicId(URI.create("urn:topic:2"));
-        Node subsubnode = nodeRepository.findNodeGraphByPublicId(URI.create("urn:topic:3"));
+        Resource resource = (Resource) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:resource:1"), false, false).get();
+        Node subnode = (Node) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:topic:2"), false, false).get();
+        Node subsubnode = (Node) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:topic:3"), false, false).get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(resource);
@@ -306,7 +310,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Resource updated = resourceRepository.findResourceGraphByPublicId(URI.create("urn:resource:1"));
+        Resource updated = (Resource) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:resource:1"), false, false).get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(updated);
@@ -352,7 +357,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Node updatedChild = nodeRepository.findNodeGraphByPublicId(child.getPublicId());
+        Node updatedChild = (Node) domainEntityHelperService
+                .getProcessedEntityByPublicId(child.getPublicId(), false, false).get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(updatedChild);
@@ -396,7 +402,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Resource updated = resourceRepository.findResourceGraphByPublicId(resource.getPublicId());
+        Resource updated = (Resource) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:resource:1"), false, false).get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(updated);
@@ -469,7 +476,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         }
 
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Resource updated = resourceRepository.findResourceGraphByPublicId(URI.create("urn:resource:1"));
+        Resource updated = (Resource) domainEntityHelperService
+                .getProcessedEntityByPublicId(URI.create("urn:resource:1"), false, false).get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(updated);
@@ -584,7 +592,8 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
 
         // Check node is published to schema
         VersionContext.setCurrentVersion(versionService.schemaFromHash(target.getHash()));
-        Node published = nodeRepository.findNodeGraphByPublicId(node.getPublicId());
+        Node published = (Node) domainEntityHelperService.getProcessedEntityByPublicId(node.getPublicId(), false, false)
+                .get();
         VersionContext.setCurrentVersion(versionService.schemaFromHash(null));
 
         assertNotNull(published);


### PR DESCRIPTION
Funksjonellt er det ikkje så voldsomt endringer, anna enn flytting av kode fra ChangelogService til DomainEntityHelperService for å samle koden.

Det viktige her er å slutte å bruke EntityGraph for å hente masse data på en gong. Det blei uansett innført for å omgå problemer med lukka databasesessions ved traversering av henta data. Dette er bytta ut med en enklere traversering av sets i domeneklasser, noko som tvinger hibernate til å populere disse felta.

Med gammel kode såg eg minnebruk på opp mot 4-5G ved prosessering av endringslogg, men med denne koden så ligger minnebruken stabilt mellom 70-200MB! Til gjengjeld blir det nok meir databasekommunikasjon i og med at data hentes ved traversering og ikkje i forkant. Men det kan vi bøte på med større databaseinstans dersom det skulle vise seg som et behov.

Tester også ut en ny GC: https://www.baeldung.com/jvm-garbage-collectors#6-z-garbage-collector