### PR TITLE
Set max pool size for migrations

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/LiquibaseConfig.java
+++ b/src/main/java/no/ndla/taxonomy/config/LiquibaseConfig.java
@@ -78,6 +78,7 @@ public class LiquibaseConfig implements InitializingBean, ResourceLoaderAware {
             var ds = dataSource;
             if (!"".equals(dataSourceUsername)) {
                 var hc = new HikariConfig();
+                hc.setMaximumPoolSize(1);
                 hc.setSchema(schema);
                 hc.setUsername(dataSourceUsername);
                 hc.setPassword(dataSourcePassword);


### PR DESCRIPTION
Vi trenger nok ikke mer en 1 connection pr schema her og den tok opp veeeldig mange i databasen under migrering.
Åpen for å finne bedre løsninger på det her, men jeg ser ingen når vi har forskjellige type connections.

Hadde vi kunt casta `DataSource` til `HikariDataSource` så kunne vi brukt `.setSchema` på den, men det så ikke ut til å fungere.