### PR TITLE
Using uris over ids for fetching.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
+++ b/src/main/java/no/ndla/taxonomy/domain/EntityWithPath.java
@@ -48,9 +48,7 @@ public abstract class EntityWithPath extends DomainObject implements EntityWithM
         return this.getParentConnections().stream().findFirst();
     }
 
-    public Optional<String> getPathByContext(DomainEntity context) {
-        final var contextPublicId = context.getPublicId();
-
+    public Optional<String> getPathByContext(URI contextPublicId) {
         var cp = getCachedPaths();
         return cp.stream().sorted((cachedUrl1, cachedUrl2) -> {
             final var path1 = cachedUrl1.getPath();

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
@@ -26,10 +26,10 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
             JOIN FETCH nc.parent p
             JOIN FETCH nc.child c
             LEFT JOIN FETCH nc.relevance rel
-            WHERE nc.parent.id IN :nodeId
+            WHERE nc.parent.publicId IN :nodeId
             AND ((:nodeTypes) IS NULL OR c.nodeType in :nodeTypes)
             """)
-    List<NodeConnection> findAllByNodeIdInIncludingTopicAndSubtopic(Set<Integer> nodeId, List<NodeType> nodeTypes);
+    List<NodeConnection> findAllByNodeIdInIncludingTopicAndSubtopic(Set<URI> nodeId, List<NodeType> nodeTypes);
 
     @Query("""
             SELECT DISTINCT nc FROM NodeConnection nc
@@ -38,12 +38,12 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
             LEFT JOIN FETCH child.resourceResourceTypes rrt
             LEFT JOIN FETCH nc.relevance rel
             LEFT JOIN FETCH rrt.resourceType rt
-            WHERE n.id IN :nodeIds
+            WHERE n.publicId IN :nodeIds
             AND (:resourceTypePublicIds IS NULL OR rt.publicId IN :resourceTypePublicIds)
             AND (:relevancePublicId IS NULL OR rel.publicId = :relevancePublicId)
             AND child.nodeType = 'RESOURCE'
             """)
-    List<NodeConnection> getResourceBy(Set<Integer> nodeIds, Set<URI> resourceTypePublicIds, URI relevancePublicId);
+    List<NodeConnection> getResourceBy(Set<URI> nodeIds, Set<URI> resourceTypePublicIds, URI relevancePublicId);
 
     @Query("""
             SELECT DISTINCT nc FROM NodeConnection nc
@@ -52,10 +52,10 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
             LEFT JOIN FETCH r.resourceResourceTypes rrt
             LEFT JOIN FETCH nc.relevance rel
             LEFT JOIN FETCH rrt.resourceType rt
-            WHERE n.id IN :nodeIds
+            WHERE n.publicId IN :nodeIds
             AND r.nodeType = 'RESOURCE'
             """)
-    List<NodeConnection> getByResourceIds(Collection<Integer> nodeIds);
+    List<NodeConnection> getByResourceIds(Collection<URI> nodeIds);
 
     @Query("SELECT nc FROM NodeConnection nc JOIN FETCH nc.parent JOIN FETCH nc.child")
     List<NodeConnection> findAllIncludingParentAndChild();
@@ -91,11 +91,10 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
             FROM NodeConnection nc
             JOIN FETCH nc.parent n
             JOIN FETCH nc.child c
-            WHERE nc.child.id IN :nodeId""")
-    List<NodeConnection> doFindAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<Integer> nodeId);
+            WHERE nc.child.publicId IN :nodeId""")
+    List<NodeConnection> doFindAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<URI> nodeId);
 
-    default List<NodeConnection> findAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(
-            Collection<Integer> nodeId) {
+    default List<NodeConnection> findAllByChildIdIncludeTranslationsAndCachedUrlsAndFilters(Collection<URI> nodeId) {
         if (nodeId.size() == 0) {
             return List.of();
         }

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -148,7 +148,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             URI relevancePublicId, String languageCode, boolean recursive) {
         final var node = domainEntityHelperService.getNodeByPublicId(nodePublicId);
 
-        final Set<Integer> topicIdsToSearchFor;
+        final Set<URI> topicIdsToSearchFor;
 
         // Add both topics and resourceTopics to a common list that will be sorted in a tree-structure based on rank at
         // each level
@@ -161,19 +161,19 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             final var nodeList = recursiveNodeTreeService.getRecursiveNodes(node);
 
             nodeList.forEach(treeElement -> resourcesToSort.add(new ResourceTreeSortable<Node>("node", "node",
-                    treeElement.getId(), treeElement.getParentId().orElse(0), treeElement.getRank())));
+                    treeElement.getId(), treeElement.getParentId().orElse(URI.create("")), treeElement.getRank())));
 
             topicIdsToSearchFor = nodeList.stream().map(RecursiveNodeTreeService.TreeElement::getId)
                     .collect(Collectors.toSet());
         } else {
-            topicIdsToSearchFor = Set.of(node.getId());
+            topicIdsToSearchFor = Set.of(node.getPublicId());
         }
 
         return filterNodeResourcesByIdsAndReturn(topicIdsToSearchFor, resourceTypeIds, relevancePublicId,
                 resourcesToSort, languageCode);
     }
 
-    private List<ResourceWithNodeConnectionDTO> filterNodeResourcesByIdsAndReturn(Set<Integer> nodeIds,
+    private List<ResourceWithNodeConnectionDTO> filterNodeResourcesByIdsAndReturn(Set<URI> nodeIds,
             Set<URI> resourceTypeIds, URI relevance, Set<ResourceTreeSortable<Node>> sortableListToAddTo,
             String languageCode) {
         final List<NodeConnection> nodeResources;

--- a/src/main/java/no/ndla/taxonomy/service/ResourceTreeSortable.java
+++ b/src/main/java/no/ndla/taxonomy/service/ResourceTreeSortable.java
@@ -16,24 +16,24 @@ import java.util.Optional;
 
 public class ResourceTreeSortable<T extends EntityWithPath> implements TreeSorter.Sortable {
     private int rank;
-    private int id;
-    private int parentId;
+    private URI id;
+    private URI parentId;
     private SortableResourceConnection<T> resourceConnection;
     private String parentType;
     private String type;
 
     public ResourceTreeSortable(SortableResourceConnection<T> resourceConnection) {
         this.id = resourceConnection.getResource().orElseThrow(() -> new IllegalArgumentException("Resource not set"))
-                .getId();
+                .getPublicId();
         this.parentId = resourceConnection.getParent().orElseThrow(() -> new IllegalArgumentException("Parent not set"))
-                .getId();
+                .getPublicId();
         this.rank = resourceConnection.getRank();
         this.resourceConnection = resourceConnection;
         this.type = "resource";
         this.parentType = "node";
     }
 
-    public ResourceTreeSortable(String type, String parentType, int id, int parentId, int rank) {
+    public ResourceTreeSortable(String type, String parentType, URI id, URI parentId, int rank) {
         this.id = id;
         this.parentId = parentId;
         this.rank = rank;

--- a/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/EntityWithPathChildDTO.java
@@ -79,9 +79,11 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
         // This must be enabled when ed is updated to update metadata for connections.
         // this.metadata = new MetadataDto(nodeConnection.getMetadata());
 
+        nodeConnection.getParent().ifPresent(parent -> this.parent = parent.getPublicId());
+
         nodeConnection.getChild().ifPresent(child -> {
             this.populateFromNode(child);
-            this.path = child.getPathByContext(node).orElse("");
+            this.path = child.getPathByContext(this.parent).orElse("");
             this.paths = child.getAllPaths();
 
             var translations = child.getTranslations();
@@ -93,8 +95,6 @@ public abstract class EntityWithPathChildDTO implements TreeSorter.Sortable {
 
             this.nodeType = child.getNodeType();
         });
-
-        nodeConnection.getParent().ifPresent(parent -> this.parent = parent.getPublicId());
 
         this.rank = nodeConnection.getRank();
 

--- a/src/test/java/no/ndla/taxonomy/domain/EntityWithPathTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/EntityWithPathTest.java
@@ -90,12 +90,12 @@ public class EntityWithPathTest {
         when(entityWithPath.getCachedPaths())
                 .thenReturn(Set.of(cachedUrl1, cachedUrl2, cachedUrl31, cachedUrl3, cachedUrl4));
 
-        assertEquals("/context1/path1", entityWithPath.getPathByContext(context1).get());
-        assertEquals("/context2/path1", entityWithPath.getPathByContext(context2).get());
-        assertEquals("/context3/path1", entityWithPath.getPathByContext(context3).get());
-        assertEquals("/context4/path1", entityWithPath.getPathByContext(context4).get());
-        assertTrue(
-                Set.of("/context2/path1", "/context3/path1").contains(entityWithPath.getPathByContext(context5).get()));
+        assertEquals("/context1/path1", entityWithPath.getPathByContext(context1.getPublicId()).get());
+        assertEquals("/context2/path1", entityWithPath.getPathByContext(context2.getPublicId()).get());
+        assertEquals("/context3/path1", entityWithPath.getPathByContext(context3.getPublicId()).get());
+        assertEquals("/context4/path1", entityWithPath.getPathByContext(context4.getPublicId()).get());
+        assertTrue(Set.of("/context2/path1", "/context3/path1")
+                .contains(entityWithPath.getPathByContext(context5.getPublicId()).get()));
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/service/RecursiveNodeTreeServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/RecursiveNodeTreeServiceImplTest.java
@@ -59,7 +59,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
         final var topic5 = nodeRepository.findFirstByPublicId(URI.create("urn:topic:5")).orElseThrow();
 
         recursiveNodes.forEach(topicTreeElement -> {
-            final var node = nodeRepository.findById(topicTreeElement.getId()).orElseThrow();
+            final var node = nodeRepository.findFirstByPublicId(topicTreeElement.getId()).orElseThrow();
 
             if (!nodesToFind.contains(node.getPublicId().toString())) {
                 fail("Topic found is unknown or duplicated " + node.getPublicId());
@@ -68,55 +68,55 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
             switch (node.getPublicId().toString()) {
             case "urn:subject:1":
                 // Root node
-                assertEquals(subject.getId(), topicTreeElement.getId());
+                assertEquals(subject.getPublicId(), topicTreeElement.getId());
                 assertFalse(topicTreeElement.getParentId().isPresent());
                 break;
             case "urn:topic:1":
                 // Child if subject
-                assertEquals(subject.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(subject.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertTrue(topicTreeElement.getParentId().isPresent());
                 assertEquals(1, topicTreeElement.getRank());
                 break;
             case "urn:topic:2":
                 // Child of topic 1
                 assertTrue(topicTreeElement.getParentId().isPresent());
-                assertEquals(topic1.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(topic1.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertEquals(1, topicTreeElement.getRank());
                 break;
             case "urn:topic:3":
                 // Child if subject
-                assertEquals(subject.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(subject.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertTrue(topicTreeElement.getParentId().isPresent());
                 assertEquals(2, topicTreeElement.getRank());
                 break;
             case "urn:topic:4":
                 // Child of topic 3
                 assertTrue(topicTreeElement.getParentId().isPresent());
-                assertEquals(topic3.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(topic3.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertEquals(1, topicTreeElement.getRank());
                 break;
             case "urn:topic:5":
                 // Child if subject
-                assertEquals(subject.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(subject.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertTrue(topicTreeElement.getParentId().isPresent());
                 assertEquals(3, topicTreeElement.getRank());
                 break;
             case "urn:topic:6":
                 // Child of topic 5
                 assertTrue(topicTreeElement.getParentId().isPresent());
-                assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertEquals(1, topicTreeElement.getRank());
                 break;
             case "urn:topic:7":
                 // Child of topic 5
                 assertTrue(topicTreeElement.getParentId().isPresent());
-                assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertEquals(2, topicTreeElement.getRank());
                 break;
             case "urn:topic:8":
                 // Child of topic 5
                 assertTrue(topicTreeElement.getParentId().isPresent());
-                assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                 assertEquals(3, topicTreeElement.getRank());
                 break;
             default:
@@ -142,7 +142,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
             final var topicsToFind = new HashSet<>(Set.of("urn:topic:1", "urn:topic:2"));
 
             topicElements.forEach(topicTreeElement -> {
-                final var topic = nodeRepository.findById(topicTreeElement.getId()).orElseThrow();
+                final var topic = nodeRepository.findFirstByPublicId(topicTreeElement.getId()).orElseThrow();
 
                 if (!topicsToFind.contains(topic.getPublicId().toString())) {
                     fail("Topic found is unknown or duplicated " + topic.getPublicId());
@@ -155,7 +155,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
                     break;
                 case "urn:topic:2":
                     assertTrue(topicTreeElement.getParentId().isPresent());
-                    assertEquals(topic1.getId(), topicTreeElement.getParentId().orElseThrow());
+                    assertEquals(topic1.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                     assertEquals(1, topicTreeElement.getRank());
                     break;
                 default:
@@ -174,7 +174,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
             final var topicsToFind = new HashSet<>(Set.of("urn:topic:3", "urn:topic:4"));
 
             topicElements.forEach(topicTreeElement -> {
-                final var topic = nodeRepository.findById(topicTreeElement.getId()).orElseThrow();
+                final var topic = nodeRepository.findFirstByPublicId(topicTreeElement.getId()).orElseThrow();
 
                 if (!topicsToFind.contains(topic.getPublicId().toString())) {
                     fail("Topic found is unknown or duplicated " + topic.getPublicId());
@@ -187,7 +187,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
                     break;
                 case "urn:topic:4":
                     assertTrue(topicTreeElement.getParentId().isPresent());
-                    assertEquals(topic3.getId(), topicTreeElement.getParentId().orElseThrow());
+                    assertEquals(topic3.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                     assertEquals(1, topicTreeElement.getRank());
                     break;
                 default:
@@ -206,7 +206,7 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
             final var topicsToFind = new HashSet<>(Set.of("urn:topic:5", "urn:topic:6", "urn:topic:7", "urn:topic:8"));
 
             topicElements.forEach(topicTreeElement -> {
-                final var topic = nodeRepository.findById(topicTreeElement.getId()).orElseThrow();
+                final var topic = nodeRepository.findFirstByPublicId(topicTreeElement.getId()).orElseThrow();
 
                 if (!topicsToFind.contains(topic.getPublicId().toString())) {
                     fail("Topic found is unknown or duplicated " + topic.getPublicId());
@@ -219,17 +219,17 @@ class RecursiveNodeTreeServiceImplTest extends AbstractIntegrationTest {
                     break;
                 case "urn:topic:6":
                     assertTrue(topicTreeElement.getParentId().isPresent());
-                    assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                    assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                     assertEquals(1, topicTreeElement.getRank());
                     break;
                 case "urn:topic:7":
                     assertTrue(topicTreeElement.getParentId().isPresent());
-                    assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                    assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                     assertEquals(2, topicTreeElement.getRank());
                     break;
                 case "urn:topic:8":
                     assertTrue(topicTreeElement.getParentId().isPresent());
-                    assertEquals(topic5.getId(), topicTreeElement.getParentId().orElseThrow());
+                    assertEquals(topic5.getPublicId(), topicTreeElement.getParentId().orElseThrow());
                     assertEquals(3, topicTreeElement.getRank());
                     break;
                 default:

--- a/src/test/java/no/ndla/taxonomy/service/ResourceTreeSortableTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/ResourceTreeSortableTest.java
@@ -24,29 +24,31 @@ public class ResourceTreeSortableTest {
     public void getSortableRank() {
 
         // TopicResource
-        var sortable = new ResourceTreeSortable<Node>("resource", "topic", 100, 10, 1000);
+        var sortable = new ResourceTreeSortable<Node>("resource", "topic", URI.create("100"), URI.create("10"), 1000);
         assertEquals(1000 - 10000, sortable.getSortableRank());
 
         // TopicSubtopic
-        sortable = new ResourceTreeSortable<Node>("topic", "topic", 100, 10, 800);
+        sortable = new ResourceTreeSortable<Node>("topic", "topic", URI.create("100"), URI.create("10"), 800);
         assertEquals(800 - 1000, sortable.getSortableRank());
     }
 
     @Test
     public void getSortableId() throws URISyntaxException {
-        final var sortable = new ResourceTreeSortable<Node>("resource", "topic", 100, 10, 1000);
+        final var sortable = new ResourceTreeSortable<Node>("resource", "topic", URI.create("100"), URI.create("10"),
+                1000);
         assertEquals(new URI("urn:resource:100"), sortable.getSortableId());
     }
 
     @Test
     public void getSortableParentId() throws URISyntaxException {
-        final var sortable = new ResourceTreeSortable<Node>("resource", "topic", 100, 10, 1000);
+        final var sortable = new ResourceTreeSortable<Node>("resource", "topic", URI.create("100"), URI.create("10"),
+                1000);
         assertEquals(new URI("urn:topic:10"), sortable.getSortableParentId());
     }
 
     @Test
     public void getNodeResource() {
-        var sortable = new ResourceTreeSortable<Node>("resource", "topic", 100, 10, 1000);
+        var sortable = new ResourceTreeSortable<Node>("resource", "topic", URI.create("100"), URI.create("10"), 1000);
         assertFalse(sortable.getResourceConnection().isPresent());
 
         final var node = mock(Node.class);
@@ -71,8 +73,8 @@ public class ResourceTreeSortableTest {
         final var resource = mock(Node.class);
         final var nodeResource = mock(NodeConnection.class);
 
-        when(node.getId()).thenReturn(101);
-        when(resource.getId()).thenReturn(102);
+        when(node.getPublicId()).thenReturn(URI.create("101"));
+        when(resource.getPublicId()).thenReturn(URI.create("102"));
 
         when(nodeResource.getParent()).thenReturn(Optional.of(node));
         when(nodeResource.getResource()).thenReturn(Optional.of(resource));


### PR DESCRIPTION
Needed to filter out correct parents in Nodes and Subjects.

Etter siste omskriving av taksonomi så funker det ikkje å sammenligne nodetre fordi parent som returneres i lista ikkje stemmer overens. Dette fikser det ved å eksplisitt sjekke at ids som returneres er i lista som hentes.

Det som fremdeles er et lite issue er at parent og path som returneres ikkje stemmer overens, men det har det ikkje gjort før heller.