### PR TITLE
Resetting context after completion.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/VersionRequestInterceptor.java
+++ b/src/main/java/no/ndla/taxonomy/service/VersionRequestInterceptor.java
@@ -37,8 +37,8 @@ public class VersionRequestInterceptor implements AsyncHandlerInterceptor {
     }
 
     @Override
-    public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler,
-            ModelAndView modelAndView) {
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex)
+            throws Exception {
         VersionContext.clear();
     }
 


### PR DESCRIPTION
Det er tydeligvis ikkje nok å resette context ved postHandle for det kan føre til at tråden beholder contexten. Det må gjøres ved afterCompletion.

Uten dette klarte eg konsekvent å hente data fra upublisert skjema uten å sende inn header:

```
2023-03-22 13:35:21.372  INFO 7 --- [-5000-exec-2266] n.n.t.config.RequestLoggerInterceptor    : (e5fd7c75-1cdb-4bb4-a4b7-4934abd3da56) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 16ms with code 200
2023-03-22 13:35:22.407  INFO 7 --- [-5000-exec-2238] n.n.t.config.RequestLoggerInterceptor    : (0c2d2b1d-e2c8-49bf-87d4-1b314a3a0f9e) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 9ms with code 404
2023-03-22 13:35:23.565  INFO 7 --- [-5000-exec-2336] n.n.t.config.RequestLoggerInterceptor    : (7f9b1e59-63cb-4f72-8c6a-359445ca7a97) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 10ms with code 404
2023-03-22 13:35:24.436  INFO 7 --- [-5000-exec-2316] n.n.t.config.RequestLoggerInterceptor    : (c941fcbe-78d0-4905-98e5-3661b4b0f6cb) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 9ms with code 404
2023-03-22 13:35:58.876  INFO 7 --- [-5000-exec-2324] n.n.t.config.RequestLoggerInterceptor    : (c4684a8f-c4cc-44c7-a3c3-e9b754c2a95e) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 10ms with code 404
2023-03-22 13:35:59.915  INFO 7 --- [-5000-exec-2344] n.n.t.config.RequestLoggerInterceptor    : (5ccdb2a6-14fa-4b34-be15-89edcc00a9ab) GET /v1/resources/urn%3Aresource%3A87d5756d-8121-437e-b18c-4c2abc0c3e58?language=nb () executed in 51ms with code 200
Logs from 22.3.2023, 13:34:27
```

Loggen viser at samme ressurs gir 404 og 200 fra samme server!