### PR TITLE
Returns list of contexts for node.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Context.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Context.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 /**
  * Identifies a unique context for any node. A context is a position for a node in the structure, identified by root
  * node and parent-connection
- * 
+ *
  * @param rootId
  *            The publicId of the node at the root of the context.
  * @param rootName
@@ -24,8 +24,8 @@ import java.util.Optional;
  *            Breadcrumbs corresponding with the path.
  * @param contextType
  *            Type resource. Fetched from node.
- * @param parentId
- *            Parent of the node. From the other end of the nodeConnection.
+ * @param parentIds
+ *            Parents of the node. From the other end of the nodeConnection.
  * @param isVisible
  *            Metadata from node.
  * @param isPrimary
@@ -36,6 +36,6 @@ import java.util.Optional;
  *            Hash of root publicId + nodeConnection publicId. Unique for this context.
  */
 public record Context(String rootId, LanguageField<String> rootName, String path,
-        LanguageField<List<String>> breadcrumbs, Optional<String> contextType, Optional<String> parentId,
+        LanguageField<List<String>> breadcrumbs, Optional<String> contextType, List<String> parentIds,
         boolean isVisible, boolean isPrimary, String relevanceId, String contextId) {
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/nodes/searchapi/SearchableTaxonomyResourceType.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/nodes/searchapi/SearchableTaxonomyResourceType.java
@@ -14,6 +14,9 @@ public class SearchableTaxonomyResourceType {
     @JsonProperty
     private HashMap<String, String> name;
 
+    public SearchableTaxonomyResourceType() {
+    }
+
     public SearchableTaxonomyResourceType(ResourceType resourceType) {
         var translations = resourceType.getTranslations();
         this.id = resourceType.getPublicId().toString();

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/nodes/searchapi/TaxonomyContextDTO.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/nodes/searchapi/TaxonomyContextDTO.java
@@ -27,6 +27,7 @@ public record TaxonomyContextDTO(
         @JsonProperty @Schema(description = "Resource-types of the base") List<SearchableTaxonomyResourceType> resourceTypes,
         @JsonProperty @Schema(description = "List of all parent topic-ids") List<URI> parentIds,
         @JsonProperty @Schema(description = "Whether the base connection is primary or not") boolean isPrimary,
+        @JsonProperty @Schema(description = "Whether the base connection is visible or not") boolean isVisible,
         @JsonProperty @Schema(description = "Unique id of context based on root + connection") String contextId) {
 
     @JsonProperty

--- a/src/main/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/CachedUrlUpdaterServiceImpl.java
@@ -17,10 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -38,7 +35,7 @@ public class CachedUrlUpdaterServiceImpl implements CachedUrlUpdaterService {
         if (entity.isContext()) {
             returnedContexts.add(new Context(entity.getPublicId().toString(), LanguageField.fromNode(entity),
                     "/" + entity.getPublicId().getSchemeSpecificPart(), new LanguageField<List<String>>(),
-                    entity.getContextType(), Optional.empty(), entity.isVisible(), true, "urn:relevance:core",
+                    entity.getContextType(), new ArrayList<>(), entity.isVisible(), true, "urn:relevance:core",
                     HashUtil.semiHash(entity.getPublicId())));
         }
 
@@ -48,10 +45,12 @@ public class CachedUrlUpdaterServiceImpl implements CachedUrlUpdaterService {
             createContexts(parent).stream().map(parentContext -> {
                 var breadcrumbs = LanguageField.listFromLists(parentContext.breadcrumbs(),
                         LanguageField.fromNode(parent));
+                List<String> parentIds = parentContext.parentIds();
+                parentIds.add(parent.getPublicId().toString());
                 return new Context(parentContext.rootId(), parentContext.rootName(),
                         parentContext.path() + "/" + entity.getPublicId().getSchemeSpecificPart(), breadcrumbs,
-                        entity.getContextType(), Optional.of(parent.getPublicId().toString()),
-                        parentContext.isVisible() && entity.isVisible(), parentConnection.isPrimary().orElse(true),
+                        entity.getContextType(), parentIds, parentContext.isVisible() && entity.isVisible(),
+                        parentConnection.isPrimary().orElse(true),
                         parentConnection.getRelevance()
                                 .flatMap(relevance -> Optional.of(relevance.getPublicId().toString()))
                                 .orElse("urn:relevance:core"),

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -338,8 +338,6 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
 
     List<TaxonomyContextDTO> nodesToContexts(List<Node> nodes, boolean filterVisibles) {
         return nodes.stream().flatMap(node -> {
-            var parentIds = node.getContexts().stream().map(Context::parentId).flatMap(s -> s.stream().map(URI::create))
-                    .toList();
             var contexts = filterVisibles
                     ? node.getContexts().stream().filter(Context::isVisible).collect(Collectors.toSet())
                     : node.getContexts();
@@ -356,7 +354,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                         LanguageFieldDTO.fromLanguageField(context.rootName()), context.path(),
                         LanguageFieldDTO.fromLanguageFieldList(breadcrumbs), context.contextType(),
                         URI.create(context.relevanceId()), LanguageFieldDTO.fromLanguageField(relevanceName),
-                        resourceTypes, parentIds, context.isPrimary(), context.contextId());
+                        resourceTypes, context.parentIds().stream().map(URI::create).toList(), context.isPrimary(),
+                        context.isVisible(), context.contextId());
             });
         }).toList();
     }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
@@ -163,7 +163,7 @@ public class QueryTest extends RestTest {
 
         var firstResult = result[0];
         assertEquals(URI.create("urn:resource:1"), firstResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:3")),
+        assertEquals(List.of(URI.create("urn:subject:1"), URI.create("urn:topic:1")),
                 firstResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:1"), firstResult.subjectId());
         assertEquals("/subject:1/topic:1/resource:1", firstResult.path());
@@ -174,7 +174,7 @@ public class QueryTest extends RestTest {
 
         var secondResult = result[1];
         assertEquals(URI.create("urn:resource:1"), secondResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:3")),
+        assertEquals(List.of(URI.create("urn:subject:2"), URI.create("urn:topic:2")),
                 secondResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:2"), secondResult.subjectId());
         assertEquals("/subject:2/topic:2/resource:1", secondResult.path());
@@ -211,7 +211,7 @@ public class QueryTest extends RestTest {
         assertEquals(3, result.length);
         var firstResult = result[0];
         assertEquals(URI.create("urn:resource:1"), firstResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:3")),
+        assertEquals(List.of(URI.create("urn:subject:1"), URI.create("urn:topic:1")),
                 firstResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:1"), firstResult.subjectId());
         assertEquals("/subject:1/topic:1/resource:1", firstResult.path());
@@ -222,7 +222,7 @@ public class QueryTest extends RestTest {
 
         var secondResult = result[1];
         assertEquals(URI.create("urn:resource:1"), secondResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:3")),
+        assertEquals(List.of(URI.create("urn:subject:2"), URI.create("urn:topic:2")),
                 secondResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:2"), secondResult.subjectId());
         assertEquals("/subject:2/topic:2/resource:1", secondResult.path());
@@ -233,7 +233,7 @@ public class QueryTest extends RestTest {
 
         var thirdResult = result[2];
         assertEquals(URI.create("urn:resource:1"), thirdResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:3")),
+        assertEquals(List.of(URI.create("urn:subject:3"), URI.create("urn:topic:3")),
                 thirdResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:3"), thirdResult.subjectId());
         assertEquals("/subject:3/topic:3/resource:1", thirdResult.path());
@@ -263,9 +263,9 @@ public class QueryTest extends RestTest {
         var result = testUtils.getObject(TaxonomyContextDTO[].class, response);
 
         assertEquals(2, result.length);
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2")),
+        assertEquals(List.of(URI.create("urn:subject:1"), URI.create("urn:topic:1")),
                 result[0].parentTopicIds().stream().sorted().toList());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2")),
+        assertEquals(List.of(URI.create("urn:subject:2"), URI.create("urn:topic:2")),
                 result[1].parentTopicIds().stream().sorted().toList());
     }
 
@@ -292,7 +292,7 @@ public class QueryTest extends RestTest {
         assertEquals(3, result.length);
         var firstResult = result[0];
         assertEquals(URI.create("urn:resource:1"), firstResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:2")),
+        assertEquals(List.of(URI.create("urn:subject:1"), URI.create("urn:topic:1")),
                 firstResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:1"), firstResult.subjectId());
         assertEquals("/subject:1/topic:1/resource:1", firstResult.path());
@@ -303,7 +303,7 @@ public class QueryTest extends RestTest {
 
         var secondResult = result[1];
         assertEquals(URI.create("urn:resource:1"), secondResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:2")),
+        assertEquals(List.of(URI.create("urn:subject:2"), URI.create("urn:topic:2")),
                 secondResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:subject:2"), secondResult.subjectId());
         assertEquals("/subject:2/topic:2/resource:1", secondResult.path());
@@ -314,8 +314,7 @@ public class QueryTest extends RestTest {
 
         var thirdResult = result[2];
         assertEquals(URI.create("urn:resource:1"), thirdResult.id());
-        assertEquals(List.of(URI.create("urn:topic:1"), URI.create("urn:topic:2"), URI.create("urn:topic:2")),
-                thirdResult.parentTopicIds().stream().sorted().toList());
+        assertEquals(List.of(URI.create("urn:topic:2")), thirdResult.parentTopicIds().stream().sorted().toList());
         assertEquals(URI.create("urn:topic:2"), thirdResult.subjectId());
         assertEquals("/topic:2/resource:1", thirdResult.path());
         assertEquals(URI.create("urn:relevance:core"), thirdResult.relevanceId());


### PR DESCRIPTION
Returnerer alle kontekster per node. Trengs for indeksering i search-api. Returnerer også visible-flagg for filtering i search-api.
Fant ut basert på tester i search-api at parentIds for context er liste med parents for den konteksten og ikkje aller parents. Dette endrer testene litt.