### PR TITLE
Only return contexts for node if asked. Ignore for old types.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -68,7 +68,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "Filter by visible") @RequestParam(value = "isVisible", required = false) Optional<Boolean> isVisible) {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         return nodeService.getNodesByType(Optional.of(List.of(NodeType.RESOURCE)), language, contentUri,
-                Optional.empty(), Optional.empty(), metadataFilters);
+                Optional.empty(), Optional.empty(), metadataFilters, Optional.of(false));
     }
 
     @GetMapping("/search")
@@ -79,10 +79,9 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "How many results to return per page") @RequestParam(value = "pageSize", defaultValue = "10") int pageSize,
             @Parameter(description = "Which page to fetch") @RequestParam(value = "page", defaultValue = "1") int page,
             @Parameter(description = "Query to search names") @RequestParam(value = "query", required = false) Optional<String> query,
-            @Parameter(description = "Ids to fetch for query") @RequestParam(value = "ids", required = false) Optional<List<String>> ids
-
-    ) {
-        return nodeService.searchByNodeType(query, ids, language, pageSize, page, Optional.of(NodeType.RESOURCE));
+            @Parameter(description = "Ids to fetch for query") @RequestParam(value = "ids", required = false) Optional<List<String>> ids) {
+        return nodeService.searchByNodeType(query, ids, language, Optional.of(false), pageSize, page,
+                Optional.of(NodeType.RESOURCE));
     }
 
     @GetMapping("/page")
@@ -101,9 +100,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
         var pageRequest = PageRequest.of(page.get() - 1, pageSize.get());
         var ids = nodeRepository.findIdsByTypePaginated(pageRequest, NodeType.RESOURCE);
         var results = nodeRepository.findByIds(ids.getContent());
-        var contents = results.stream()
-                .map(node -> new NodeDTO(Optional.empty(), node, language.orElse("nb"), Optional.empty()))
-                .collect(Collectors.toList());
+        var contents = results.stream().map(node -> new NodeDTO(Optional.empty(), node, language.orElse("nb"),
+                Optional.empty(), Optional.of(false))).collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }
 
@@ -112,7 +110,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
     @Transactional(readOnly = true)
     public NodeDTO get(@PathVariable("id") URI id,
             @Parameter(description = "ISO-639-1 language code", example = "nb") @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage) Optional<String> language) {
-        return nodeService.getNode(id, language);
+        return nodeService.getNode(id, language, Optional.of(false));
     }
 
     @PutMapping("{id}")

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -21,7 +21,7 @@ interface ExtraSpecification<T> {
 public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends TaxonomyRepository<DOMAIN>> {
     REPO getRepository();
 
-    DTO createDTO(DOMAIN domain, String languageCode);
+    DTO createDTO(DOMAIN domain, String languageCode, Optional<Boolean> includeContexts);
 
     private Specification<DOMAIN> base() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.isNotNull(root.get("id"));
@@ -37,12 +37,13 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
     }
 
     default SearchResultDTO<DTO> search(Optional<String> query, Optional<List<String>> ids, Optional<String> language,
-            int pageSize, int page) {
-        return search(query, ids, language, pageSize, page, Optional.empty());
+            Optional<Boolean> includeContext, int pageSize, int page) {
+        return search(query, ids, language, includeContext, pageSize, page, Optional.empty());
     }
 
     default SearchResultDTO<DTO> search(Optional<String> query, Optional<List<String>> ids, Optional<String> language,
-            int pageSize, int page, Optional<ExtraSpecification<DOMAIN>> applySpecLambda) {
+            Optional<Boolean> includeContexts, int pageSize, int page,
+            Optional<ExtraSpecification<DOMAIN>> applySpecLambda) {
         if (page < 1)
             throw new IllegalArgumentException("page parameter must be bigger than 0");
 
@@ -73,7 +74,7 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
         var fetched = getRepository().findAll(spec, pageRequest);
 
         var languageCode = language.orElse("");
-        var dtos = fetched.stream().map(r -> createDTO(r, languageCode)).collect(Collectors.toList());
+        var dtos = fetched.stream().map(r -> createDTO(r, languageCode, includeContexts)).collect(Collectors.toList());
 
         return new SearchResultDTO<>(fetched.getTotalElements(), page, pageSize, dtos);
     }

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -39,9 +39,10 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
     @Schema(description = "Relevance id", example = "urn:relevance:core")
     private URI relevanceId;
 
-    public NodeChildDTO(Optional<Node> root, NodeConnection nodeConnection, String language) {
+    public NodeChildDTO(Optional<Node> root, NodeConnection nodeConnection, String language,
+            Optional<Boolean> includeContexts) {
         super(root, nodeConnection.getChild().orElseThrow(() -> new NotFoundException("Child was not found")), language,
-                Optional.empty());
+                Optional.empty(), includeContexts);
 
         // This must be enabled when ed is updated to update metadata for connections.
         // this.metadata = new MetadataDto(nodeConnection.getMetadata());
@@ -61,7 +62,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
      * Special constructor used to get parents for resource/full
      */
     public NodeChildDTO(Node parent, NodeConnection nodeConnection, String language) {
-        super(Optional.empty(), parent, language, Optional.empty());
+        super(Optional.empty(), parent, language, Optional.empty(), Optional.of(false));
 
         this.rank = nodeConnection.getRank();
         this.connectionId = nodeConnection.getPublicId();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -76,7 +76,8 @@ public class NodeDTO {
     public NodeDTO() {
     }
 
-    public NodeDTO(Optional<Node> root, Node entity, String languageCode, Optional<String> contextId) {
+    public NodeDTO(Optional<Node> root, Node entity, String languageCode, Optional<String> contextId,
+            Optional<Boolean> includeContexts) {
         this.id = entity.getPublicId();
         this.contentUri = entity.getContentUri();
 
@@ -117,20 +118,22 @@ public class NodeDTO {
             this.url = TitleUtil.createPrettyUrl(this.name, this.contextId);
         });
 
-        var relevanceName = new LanguageField<String>();
-        if (relevance.isPresent()) {
-            relevanceName = LanguageField.fromNode(relevance.get());
-        }
-        LanguageField<String> finalRelevanceName = relevanceName;
-        this.contexts = entity.getContexts().stream().map(ctx -> {
-            return new TaxonomyContextDTO(entity.getPublicId(), URI.create(ctx.rootId()),
-                    LanguageFieldDTO.fromLanguageField(ctx.rootName()), ctx.path(),
-                    LanguageFieldDTO.fromLanguageFieldList(ctx.breadcrumbs()), entity.getContextType(),
-                    URI.create(ctx.relevanceId()), LanguageFieldDTO.fromLanguageField(finalRelevanceName),
-                    entity.getResourceTypes().stream().map(SearchableTaxonomyResourceType::new).toList(),
-                    ctx.parentIds().stream().map(URI::create).toList(), ctx.isPrimary(), ctx.isVisible(),
-                    ctx.contextId());
-        }).toList();
+        includeContexts.filter(Boolean::booleanValue).ifPresent(includeCtx -> {
+            var relevanceName = new LanguageField<String>();
+            if (relevance.isPresent()) {
+                relevanceName = LanguageField.fromNode(relevance.get());
+            }
+            LanguageField<String> finalRelevanceName = relevanceName;
+            this.contexts = entity.getContexts().stream().map(ctx -> {
+                return new TaxonomyContextDTO(entity.getPublicId(), URI.create(ctx.rootId()),
+                        LanguageFieldDTO.fromLanguageField(ctx.rootName()), ctx.path(),
+                        LanguageFieldDTO.fromLanguageFieldList(ctx.breadcrumbs()), entity.getContextType(),
+                        URI.create(ctx.relevanceId()), LanguageFieldDTO.fromLanguageField(finalRelevanceName),
+                        entity.getResourceTypes().stream().map(SearchableTaxonomyResourceType::new).toList(),
+                        ctx.parentIds().stream().map(URI::create).toList(), ctx.isPrimary(), ctx.isVisible(),
+                        ctx.contextId());
+            }).toList();
+        });
     }
 
     public URI getId() {

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -30,7 +30,7 @@ public class NodeWithParents extends NodeDTO {
     }
 
     public NodeWithParents(Node node, String languageCode) {
-        super(Optional.empty(), node, languageCode, Optional.empty());
+        super(Optional.empty(), node, languageCode, Optional.empty(), Optional.of(false));
 
         node.getParentConnections().stream().map(nodeResource -> {
             Node parent = nodeResource.getParent().orElseThrow(() -> new NotFoundException("Parent not found"));

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -109,13 +109,13 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         builder.node(n -> n.nodeType(NodeType.TOPIC));
         var subject = builder.node(n -> n.nodeType(NodeType.SUBJECT));
 
-        var subjects = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(), 10, 1,
-                Optional.of(NodeType.SUBJECT));
+        var subjects = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), 10, 1, Optional.of(NodeType.SUBJECT));
 
-        var topics = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(), 10, 1,
-                Optional.of(NodeType.TOPIC));
-        var all = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(), 10, 1,
-                Optional.empty());
+        var topics = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.empty(), 10, 1, Optional.of(NodeType.TOPIC));
+        var all = nodeService.searchByNodeType(Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(),
+                10, 1, Optional.empty());
 
         assertEquals(subjects.getResults().get(0).getId(), subject.getPublicId());
 
@@ -131,7 +131,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         builder.node(n -> n.nodeType(NodeType.TOPIC).name("Hund"));
         var tiger = builder.node(n -> n.nodeType(NodeType.TOPIC).name("Tiger"));
 
-        var result = nodeService.search(Optional.of("tiger"), Optional.empty(), Optional.empty(), 10, 1);
+        var result = nodeService.search(Optional.of("tiger"), Optional.empty(), Optional.empty(), Optional.empty(), 10,
+                1);
 
         assertEquals(result.getResults().get(0).getId(), tiger.getPublicId());
         assertEquals(result.getTotalCount(), 1);
@@ -148,13 +149,15 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         idList.add("urn:topic:1");
         idList.add("urn:topic:2");
 
-        var result = nodeService.search(Optional.empty(), Optional.of(idList), Optional.empty(), 10, 1);
+        var result = nodeService.search(Optional.empty(), Optional.of(idList), Optional.empty(), Optional.empty(), 10,
+                1);
 
         assertEquals(result.getResults().get(0).getId(), new URI("urn:topic:1"));
         assertEquals(result.getResults().get(1).getId(), new URI("urn:topic:2"));
         assertEquals(result.getTotalCount(), 2);
 
-        var result2 = nodeService.search(Optional.of("Ape"), Optional.of(idList), Optional.empty(), 10, 1);
+        var result2 = nodeService.search(Optional.of("Ape"), Optional.of(idList), Optional.empty(), Optional.empty(),
+                10, 1);
 
         assertEquals(result2.getResults().get(0).getId(), new URI("urn:topic:1"));
         assertEquals(result2.getTotalCount(), 1);


### PR DESCRIPTION
Returnerer liste med kontekster kun for noder og kun dersom det bes om. Dette vil redusere payload som overføres en del.