### PR TITLE
Makes sure all breadcrumbs have same number of elements.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/LanguageField.java
+++ b/src/main/java/no/ndla/taxonomy/domain/LanguageField.java
@@ -7,13 +7,12 @@
 
 package no.ndla.taxonomy.domain;
 
+import com.google.common.collect.Sets;
 import no.ndla.taxonomy.config.Constants;
 import org.apache.commons.lang3.SerializationUtils;
 import org.springframework.data.util.Pair;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class LanguageField<V> extends HashMap<String, V> {
@@ -43,14 +42,19 @@ public class LanguageField<V> extends HashMap<String, V> {
         return breadcrumbs;
     }
 
+    /**
+     * Returns accumulated set of language fields. All additional languages from languageField are appended so all
+     * languageLists have the same number of elements. If a language variant is not present, default value is used.
+     */
     public static LanguageField<List<String>> listFromLists(LanguageField<List<String>> listLanguageField,
             LanguageField<String> languageField) {
         var breadcrumbs = SerializationUtils.clone(listLanguageField);
-        languageField.keySet().forEach(key -> {
-            var crumbs = breadcrumbs.computeIfAbsent(key, k -> new ArrayList<>());
-            if (languageField.get(key) != null) {
-                crumbs.add(languageField.get(key));
-            }
+        var languages = Sets.union(listLanguageField.keySet(), languageField.keySet());
+        var defaultValue = languageField.get(Constants.DefaultLanguage);
+        languages.forEach(lang -> {
+            var crumbs = breadcrumbs.computeIfAbsent(lang,
+                    k -> listLanguageField.getOrDefault(Constants.DefaultLanguage, new ArrayList<>()));
+            crumbs.add(languageField.getOrDefault(lang, defaultValue));
         });
         return breadcrumbs;
     }

--- a/src/test/java/no/ndla/taxonomy/domain/LanguageFieldTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/LanguageFieldTest.java
@@ -85,4 +85,36 @@ public class LanguageFieldTest {
         assertEquals(List.of("Name", "Name 2"), languageField.get("nb"));
     }
 
+    @Test
+    void test_create_language_field_list_with_complete_crumbs() {
+        Node node = new Node(NodeType.NODE);
+        node.setName("Name");
+        node.addTranslation("Name nb", "nb");
+        node.addTranslation("Name nn", "nn");
+
+        Node node2 = new Node(NodeType.NODE);
+        node2.setName("Name 2");
+        node2.addTranslation("Name 2 nb", "nb");
+        node2.addTranslation("Name 2 en", "en");
+
+        var languageField = LanguageField.listFromLists(LanguageField.listFromNode(node),
+                LanguageField.fromNode(node2));
+        assertEquals(3, languageField.size());
+        assertEquals(List.of("Name nb", "Name 2 nb"), languageField.get("nb"));
+        assertEquals(List.of("Name nn", "Name 2 nb"), languageField.get("nn"));
+        assertEquals(List.of("Name nb", "Name 2 en"), languageField.get("en"));
+
+        Node node3 = new Node(NodeType.NODE);
+        node3.setName("Name 3");
+        node3.addTranslation("Name 3 se", "se");
+
+        var languageField2 = LanguageField.listFromLists(languageField, LanguageField.fromNode(node3));
+        assertEquals(4, languageField2.size());
+        assertEquals(List.of("Name nb", "Name 2 nb", "Name 3"), languageField2.get("nb"));
+        assertEquals(List.of("Name nn", "Name 2 nb", "Name 3"), languageField2.get("nn"));
+        assertEquals(List.of("Name nb", "Name 2 en", "Name 3"), languageField2.get("en"));
+        assertEquals(List.of("Name nb", "Name 2 nb", "Name 3 se"), languageField2.get("se"));
+
+    }
+
 }


### PR DESCRIPTION
La merke til at artikler som berre finnes på nordsamisk kun har ett innslag i breadcrumbs, uavhengig av kor mange nivå det finnes ned til noden. Denne koden passer på at alle språkvarianter for breadcrumbs har like mange ledd, men med bruk av nb-variant der det er tomt ellers. Sjekk test for funksjonaliteten.