### PR TITLE
Adds customfields from parentconnections.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Context.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Context.java
@@ -9,6 +9,7 @@ package no.ndla.taxonomy.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -50,4 +51,5 @@ public record Context(
         boolean isActive,
         boolean isPrimary,
         String relevanceId,
+        Optional<Map<String, String>> customFields,
         String contextId) {}

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 // NOTE: This will need to match `SearchableTaxonomyContext` in `search-api`
@@ -30,6 +31,7 @@ public record TaxonomyContextDTO(
         @JsonProperty @Schema(description = "Whether the base connection is primary or not") boolean isPrimary,
         @JsonProperty @Schema(description = "Whether the base connection is marked as active subject") boolean isActive,
         @JsonProperty @Schema(description = "Whether the base connection is visible or not") boolean isVisible,
+        @JsonProperty @Schema(description = "Custom-fields from the parent connection") Optional<Map<String,String>> customFields,
         @JsonProperty @Schema(description = "Unique id of context based on root + connection") String contextId) {
 // spotless:on
     @JsonProperty

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -41,6 +41,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                     activeContext,
                     true,
                     "urn:relevance:core",
+                    Optional.empty(),
                     HashUtil.semiHash(node.getPublicId())));
         }
 
@@ -70,6 +71,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                                 .flatMap(relevance -> Optional.of(
                                                         relevance.getPublicId().toString()))
                                                 .orElse("urn:relevance:core"),
+                                        Optional.of(parentConnection.getCustomFields()),
                                         HashUtil.semiHash(parentContext.rootId() + parentConnection.getPublicId()));
                             })
                             .forEach(returnedContexts::add);

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -441,6 +441,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                                 context.isPrimary(),
                                 context.isActive(),
                                 context.isVisible(),
+                                context.customFields(),
                                 context.contextId());
                     });
                 })

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -153,6 +153,7 @@ public class NodeDTO {
                                 ctx.isPrimary(),
                                 ctx.isActive(),
                                 ctx.isVisible(),
+                                ctx.customFields(),
                                 ctx.contextId());
                     })
                     .toList();


### PR DESCRIPTION
Needed for programme composition in graphql-api

Tanken er at en kan knytte et fag til et programfag, og så sette feks vg1 og vg2, samt coreSubject på koblinga. Då vil faget kunne dukke opp under både vg1 og vg2 i gruppa fellesfag.