### PR TITLE
Add rank and connectionId. Replaces the need for the /full endpoint.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Context.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Context.java
@@ -15,28 +15,19 @@ import java.util.Optional;
  * Identifies a unique context for any node. A context is a position for a node in the structure, identified by root
  * node and parent-connection
  *
- * @param rootId
- *            The publicId of the node at the root of the context.
- * @param rootName
- *            The name of the root.
- * @param path
- *            The path for this connection.
- * @param breadcrumbs
- *            Breadcrumbs corresponding with the path.
- * @param contextType
- *            Type resource. Fetched from node.
- * @param parentIds
- *            Parents of the node. From the other end of the nodeConnection.
- * @param isVisible
- *            Metadata from node.
- * @param isActive
- *            Metadata from node. True if subjectCategory is active.
- * @param isPrimary
- *            Is this context marked as primary. From nodeConnection.
- * @param relevanceId
- *            Id of relevance. From nodeConnection.
- * @param contextId
- *            Hash of root publicId + nodeConnection publicId. Unique for this context.
+ * @param rootId       The publicId of the node at the root of the context.
+ * @param rootName     The name of the root.
+ * @param path         The path for this connection.
+ * @param breadcrumbs  Breadcrumbs corresponding with the path.
+ * @param contextType  Type resource. Fetched from node.
+ * @param parentIds    Parents of the node.
+ * @param isVisible    Metadata from node.
+ * @param isActive     Metadata from node. True if subjectCategory is active or otherResources.
+ * @param isPrimary    Is this context marked as primary. From nodeConnection.
+ * @param relevanceId  ID of relevance. From nodeConnection.
+ * @param contextId    Hash of root publicId + nodeConnection publicId. Unique for this context.
+ * @param rank         The rank of the context. From nodeConnection.
+ * @param connectionId The id of the connection. From nodeConnection.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Context(
@@ -50,4 +41,6 @@ public record Context(
         boolean isActive,
         boolean isPrimary,
         String relevanceId,
-        String contextId) {}
+        String contextId,
+        int rank,
+        String connectionId) {}

--- a/src/main/java/no/ndla/taxonomy/domain/DomainObject.java
+++ b/src/main/java/no/ndla/taxonomy/domain/DomainObject.java
@@ -19,6 +19,10 @@ public abstract class DomainObject extends DomainEntity implements Translatable 
         return name;
     }
 
+    public String getTranslatedName(String languageCode) {
+        return getTranslation(languageCode).map(JsonTranslation::getName).orElse(getName());
+    }
+
     public void setName(String name) {
         this.name = name;
     }

--- a/src/main/java/no/ndla/taxonomy/domain/LanguageField.java
+++ b/src/main/java/no/ndla/taxonomy/domain/LanguageField.java
@@ -35,7 +35,7 @@ public class LanguageField<V> extends HashMap<String, V> {
         langs.add(Constants.DefaultLanguage);
         for (var lang : langs) {
             var crumbs = new ArrayList<String>();
-            crumbs.add(node.getTranslation(lang).map(JsonTranslation::getName).orElse(node.getName()));
+            crumbs.add(node.getTranslatedName(lang));
             breadcrumbs.put(lang, crumbs);
         }
         return breadcrumbs;

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -120,6 +120,10 @@ public class Node extends DomainObject implements EntityWithMetadata {
         setName(node.getName());
     }
 
+    public String getPathPart() {
+        return "/" + getPublicId().getSchemeSpecificPart();
+    }
+
     private void updatePublicID() {
         super.setPublicId(URI.create("urn:" + nodeType.getName() + ":" + getIdent()));
     }
@@ -156,12 +160,10 @@ public class Node extends DomainObject implements EntityWithMetadata {
             return maybeRoot;
         }
         return contexts.stream().min((context1, context2) -> {
-            final var inPath1 = context1.path()
-                    .contains(root.map(node -> node.getPublicId().getSchemeSpecificPart())
-                            .orElse("other"));
-            final var inPath2 = context2.path()
-                    .contains(root.map(node -> node.getPublicId().getSchemeSpecificPart())
-                            .orElse("other"));
+            final var inPath1 =
+                    context1.path().contains(root.map(Node::getPathPart).orElse("other"));
+            final var inPath2 =
+                    context2.path().contains(root.map(Node::getPathPart).orElse("other"));
 
             if (inPath1 && inPath2) {
                 if (context1.isPrimary() && context2.isPrimary()) {

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Contexts.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Contexts.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import no.ndla.taxonomy.domain.Node;
-import no.ndla.taxonomy.domain.Translation;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.rest.v1.dtos.ContextDTO;
 import no.ndla.taxonomy.rest.v1.dtos.ContextPOST;
@@ -50,7 +49,7 @@ public class Contexts {
         final var contextDocuments = new ArrayList<>(nodes.stream()
                 .map(topic -> new ContextDTO(
                         topic.getPublicId(),
-                        topic.getTranslation(language).map(Translation::getName).orElse(topic.getName()),
+                        topic.getTranslatedName(language),
                         topic.getPrimaryPath().orElse(null)))
                 .toList());
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -338,8 +338,12 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
     }
 
     @GetMapping("{id}/full")
-    @Operation(summary = "Gets node including information about all parents, and resourceTypes for this resource")
+    @Operation(
+            summary = "Gets node including information about all parents, and resourceTypes for this resource. "
+                    + "Can be replaced with regular get-endpoint and traversing contexts",
+            deprecated = true)
     @Transactional(readOnly = true)
+    @Deprecated
     public NodeWithParents getNodeFull(
             @PathVariable("id") URI id,
             @Parameter(description = "ISO-639-1 language code", example = "nb")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Queries.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Queries.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import no.ndla.taxonomy.config.Constants;
 import no.ndla.taxonomy.rest.v1.dtos.searchapi.TaxonomyContextDTO;
 import no.ndla.taxonomy.service.NodeService;
 import no.ndla.taxonomy.service.dtos.NodeDTO;
@@ -36,10 +37,14 @@ public class Queries {
     @Transactional(readOnly = true)
     public List<TaxonomyContextDTO> queryFullNode(
             @PathVariable("contentURI") Optional<URI> contentURI,
+            @Parameter(description = "ISO-639-1 language code", example = "nb")
+                    @RequestParam(value = "language", defaultValue = Constants.DefaultLanguage, required = false)
+                    Optional<String> language,
             @Parameter(description = "Whether to filter out contexts if a parent (or the node itself) is non-visible")
                     @RequestParam(value = "filterVisibles", required = false, defaultValue = "true")
                     boolean filterVisibles) {
-        return nodeService.getSearchableByContentUri(contentURI, filterVisibles);
+        return nodeService.getSearchableByContentUri(
+                contentURI, filterVisibles, language.orElse(Constants.DefaultLanguage));
     }
 
     @GetMapping("/path")
@@ -47,8 +52,12 @@ public class Queries {
             summary =
                     "Gets a list of contexts matching given pretty url with contextId, empty list if no matches are found.")
     @Transactional(readOnly = true)
-    public List<TaxonomyContextDTO> queryPath(@RequestParam("path") Optional<String> path) {
-        return nodeService.getContextByPath(path);
+    public List<TaxonomyContextDTO> queryPath(
+            @RequestParam("path") Optional<String> path,
+            @Parameter(description = "ISO-639-1 language code", example = "nb")
+                    @RequestParam(value = "language", defaultValue = Constants.DefaultLanguage, required = false)
+                    Optional<String> language) {
+        return nodeService.getContextByPath(path, language.orElse(Constants.DefaultLanguage));
     }
 
     @GetMapping("/resources")
@@ -60,7 +69,7 @@ public class Queries {
     public List<NodeDTO> queryResources(
             @RequestParam("contentURI") Optional<URI> contentURI,
             @Parameter(description = "ISO-639-1 language code", example = "nb")
-                    @RequestParam(value = "language", defaultValue = "", required = false)
+                    @RequestParam(value = "language", defaultValue = Constants.DefaultLanguage, required = false)
                     Optional<String> language,
             @Parameter(description = "Filter by key and value") @RequestParam(value = "key", required = false)
                     Optional<String> key,
@@ -80,7 +89,7 @@ public class Queries {
     public List<NodeDTO> queryTopics(
             @RequestParam("contentURI") URI contentURI,
             @Parameter(description = "ISO-639-1 language code", example = "nb")
-                    @RequestParam(value = "language", defaultValue = "", required = false)
+                    @RequestParam(value = "language", defaultValue = Constants.DefaultLanguage, required = false)
                     Optional<String> language,
             @Parameter(description = "Filter by key and value") @RequestParam(value = "key", required = false)
                     Optional<String> key,

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/ResourceTypeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/ResourceTypeDTO.java
@@ -15,7 +15,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import no.ndla.taxonomy.domain.JsonTranslation;
 import no.ndla.taxonomy.domain.ResourceType;
 import no.ndla.taxonomy.service.dtos.TranslationDTO;
 
@@ -52,10 +51,7 @@ public class ResourceTypeDTO {
         this.supportedLanguages =
                 this.translations.stream().map(t -> t.language).collect(Collectors.toSet());
 
-        this.name = resourceType
-                .getTranslation(language)
-                .map(JsonTranslation::getName)
-                .orElse(resourceType.getName());
+        this.name = resourceType.getTranslatedName(language);
 
         if (recursionLevels > 0) {
             this.subtypes = resourceType.getSubtypes().stream()

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
@@ -21,16 +21,19 @@ public record TaxonomyContextDTO(
         @JsonProperty @Schema(description = "The publicId of the root parent of the context") URI rootId,
         @JsonProperty @Schema(description = "The name of the root parent of the context") LanguageFieldDTO<String> root,
         @JsonProperty @Schema(description = "The context path") String path,
-        @JsonProperty @Schema(description = "A breadcrumb of the names of the context's path") LanguageFieldDTO<List<String>> breadcrumbs,
+        @JsonProperty @Schema(description = "A breadcrumb of the names of the context's parents") LanguageFieldDTO<List<String>> breadcrumbs,
         @JsonProperty @Schema(description = "Whether a 'standard'-article, 'topic-article'-article or a 'learningpath'") Optional<String> contextType,
-        @JsonProperty @Schema(description = "Id of the relevance of the connection of the base") Optional<URI> relevanceId,
-        @JsonProperty @Schema(description = "Name of the relevance of the connection of the base") LanguageFieldDTO<String> relevance,
-        @JsonProperty @Schema(description = "Resource-types of the base") List<SearchableTaxonomyResourceType> resourceTypes,
-        @JsonProperty @Schema(description = "List of all parent topic-ids") List<URI> parentIds,
-        @JsonProperty @Schema(description = "Whether the base connection is primary or not") boolean isPrimary,
-        @JsonProperty @Schema(description = "Whether the base connection is marked as active subject") boolean isActive,
-        @JsonProperty @Schema(description = "Whether the base connection is visible or not") boolean isVisible,
-        @JsonProperty @Schema(description = "Unique id of context based on root + connection") String contextId) {
+        @JsonProperty @Schema(description = "Id of the relevance of the parent connection") Optional<URI> relevanceId,
+        @JsonProperty @Schema(description = "Name of the relevance of the parent connection") LanguageFieldDTO<String> relevance,
+        @JsonProperty @Schema(description = "Resource-types of the node") List<SearchableTaxonomyResourceType> resourceTypes,
+        @JsonProperty @Schema(description = "List of all parent ids") List<URI> parentIds,
+        @JsonProperty @Schema(description = "Whether the parent connection is primary or not") boolean isPrimary,
+        @JsonProperty @Schema(description = "Whether the parent connection is marked as active") boolean isActive,
+        @JsonProperty @Schema(description = "Whether the parent connection is visible or not") boolean isVisible,
+        @JsonProperty @Schema(description = "Unique id of context based on root + parent connection") String contextId,
+        @JsonProperty @Schema(description = "The rank of the parent connection object") int rank,
+        @JsonProperty @Schema(description = "The id of the parent connection object") String connectionId,
+        @JsonProperty @Schema(description = "Pretty-url of this particular context") Optional<String> url) {
 // spotless:on
     @JsonProperty
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -33,7 +33,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
             returnedContexts.add(new Context(
                     node.getPublicId().toString(),
                     LanguageField.fromNode(node),
-                    "/" + node.getPublicId().getSchemeSpecificPart(),
+                    node.getPathPart(),
                     new LanguageField<List<String>>(),
                     node.getContextType(),
                     new ArrayList<>(),
@@ -41,7 +41,9 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                     activeContext,
                     true,
                     "urn:relevance:core",
-                    HashUtil.semiHash(node.getPublicId())));
+                    HashUtil.semiHash(node.getPublicId()),
+                    0,
+                    ""));
         }
 
         // Get all parent connections, append this entity publicId to the end of the actual path and add
@@ -57,8 +59,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                 return new Context(
                                         parentContext.rootId(),
                                         parentContext.rootName(),
-                                        parentContext.path() + "/"
-                                                + node.getPublicId().getSchemeSpecificPart(),
+                                        parentContext.path() + node.getPathPart(),
                                         breadcrumbs,
                                         node.getContextType(),
                                         parentIds,
@@ -70,7 +71,9 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                                 .flatMap(relevance -> Optional.of(
                                                         relevance.getPublicId().toString()))
                                                 .orElse("urn:relevance:core"),
-                                        HashUtil.semiHash(parentContext.rootId() + parentConnection.getPublicId()));
+                                        HashUtil.semiHash(parentContext.rootId() + parentConnection.getPublicId()),
+                                        parentConnection.getRank(),
+                                        parentConnection.getPublicId().toString());
                             })
                             .forEach(returnedContexts::add);
                 }));

--- a/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
@@ -204,11 +204,8 @@ public class UrlResolverServiceImpl implements UrlResolverService {
 
             // Generate a string path from the sorted list of parent nodes, a cleaned version of the
             // provided string path parameter
-            resolvedUrl.setPath("/"
-                    + resolvedPathComponents.stream()
-                            .map(Node::getPublicId)
-                            .map(URI::getSchemeSpecificPart)
-                            .collect(Collectors.joining("/")));
+            resolvedUrl.setPath(
+                    resolvedPathComponents.stream().map(Node::getPathPart).collect(Collectors.joining()));
 
             return Optional.of(resolvedUrl);
         } catch (NotFoundServiceException e) {

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -94,17 +94,13 @@ public class NodeDTO {
                 entity.getParentConnections().stream().findFirst().flatMap(NodeConnection::getRelevance);
         this.relevanceId = relevance.map(Relevance::getPublicId);
 
-        var translations = entity.getTranslations();
-        this.translations =
-                translations.stream().map(TranslationDTO::new).collect(Collectors.toCollection(TreeSet::new));
+        this.translations = entity.getTranslations().stream()
+                .map(TranslationDTO::new)
+                .collect(Collectors.toCollection(TreeSet::new));
         this.supportedLanguages =
                 this.translations.stream().map(t -> t.language).collect(Collectors.toCollection(TreeSet::new));
 
-        this.name = translations.stream()
-                .filter(t -> Objects.equals(t.getLanguageCode(), languageCode))
-                .findFirst()
-                .map(Translation::getName)
-                .orElse(entity.getName());
+        this.name = entity.getTranslatedName(languageCode);
 
         this.metadata = new MetadataDTO(entity.getMetadata());
 
@@ -153,7 +149,10 @@ public class NodeDTO {
                                 ctx.isPrimary(),
                                 ctx.isActive(),
                                 ctx.isVisible(),
-                                ctx.contextId());
+                                ctx.contextId(),
+                                ctx.rank(),
+                                ctx.connectionId(),
+                                TitleUtil.createPrettyUrl(this.name, ctx.contextId()));
                     })
                     .toList();
         });

--- a/src/main/java/no/ndla/taxonomy/util/TitleUtil.java
+++ b/src/main/java/no/ndla/taxonomy/util/TitleUtil.java
@@ -14,7 +14,7 @@ public class TitleUtil {
 
     public static Optional<String> createPrettyUrl(String source, String hash) {
         if (source == null || hash == null) return Optional.empty();
-        var text = Jsoup.parse(source).text();
+        var text = Jsoup.parse(source).text().replaceAll("[.,!?\\-]", "");
         String[] words = text.split("\\s+");
         StringBuilder sb = new StringBuilder("/");
         for (int i = 0; i < words.length; i++) {

--- a/src/test/java/no/ndla/taxonomy/service/UrlResolverServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/UrlResolverServiceImplTest.java
@@ -10,7 +10,6 @@ package no.ndla.taxonomy.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
-import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import no.ndla.taxonomy.domain.Builder;
@@ -309,7 +308,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());
@@ -328,7 +327,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());
@@ -346,7 +345,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("topic:2", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("/subject:2/topic:2", resolvedUrl.getPath());
@@ -389,7 +388,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());
@@ -408,7 +407,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());
@@ -428,7 +427,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());
@@ -448,7 +447,7 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
 
             final var parentIdList = resolvedUrl.getParents().stream()
                     .map(URI::getSchemeSpecificPart)
-                    .collect(Collectors.toList());
+                    .toList();
 
             assertEquals("resource:1", resolvedUrl.getId().getSchemeSpecificPart());
             assertEquals("Resource Name", resolvedUrl.getName());

--- a/src/test/java/no/ndla/taxonomy/util/TitleUtilTest.java
+++ b/src/test/java/no/ndla/taxonomy/util/TitleUtilTest.java
@@ -21,6 +21,13 @@ public class TitleUtilTest {
     }
 
     @Test
+    void test_create_pretty_url_with_punctuation() {
+        assertEquals(
+                "/this-is-a-title-seriously__hash",
+                TitleUtil.createPrettyUrl("This is a title, seriously", "hash").get());
+    }
+
+    @Test
     void test_create_pretty_url_from_html_formatted_text() {
         assertEquals(
                 "/this-is-a-italics-title__hash",


### PR DESCRIPTION
Strip punctuation from title url.
Simplify code by adding getPathPart and getTranslatedName

Ser at i graphql-api brukes /full for å plukke ut korrekt rank og relevance fra parent, dersom du sender inn topicId som ligger rett over ressursen. Ved å legge til dette her kan vi heller hente ut korrekte verdier fra konteksten direkte uten å måtte hente ut alt av parents.