### PR TITLE
Always pick the shortest context if standalone node is fetched.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -188,7 +188,8 @@ public class Node extends DomainObject implements EntityWithMetadata {
             if (context2.isPrimary() && !context1.isPrimary()) {
                 return 1;
             }
-            return 0;
+            // contexts are of equal value, pick the shortest
+            return context1.parentIds().size() - context2.parentIds().size();
         });
     }
 


### PR DESCRIPTION
Dersom en node både er egen kontekst og del av en foreldrekontekst, og noden hentes separat, velg egen kontekst som standard. Dette gjør at subjects som er lagt inn i et programme vil ha path til egen kontekst dersom den hentes ut for seg sjølv, og dermed vil eksisterende funksjonalitet som regner med at subject er toppnivå fungere som tidligere.