### PR TITLE
Endrer måten primary plukkes ved oppdatering

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/Constants.java
+++ b/src/main/java/no/ndla/taxonomy/config/Constants.java
@@ -11,5 +11,6 @@ public final class Constants {
     public static final String DefaultLanguage = "nb";
     public static final String SubjectCategory = "subjectCategory";
     public static final String Active = "active";
+    public static final String Beta = "beta";
     public static final String OtherResources = "otherResources";
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Contexts.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Contexts.java
@@ -30,11 +30,11 @@ import org.springframework.web.bind.annotation.*;
 @Transactional(readOnly = true)
 public class Contexts {
     private final NodeRepository nodeRepository;
-    private final ContextUpdaterService cachedUrlUpdaterService;
+    private final ContextUpdaterService contextUpdaterService;
 
-    public Contexts(NodeRepository nodeRepository, ContextUpdaterService cachedUrlUpdaterService) {
+    public Contexts(NodeRepository nodeRepository, ContextUpdaterService contextUpdaterService) {
         this.nodeRepository = nodeRepository;
-        this.cachedUrlUpdaterService = cachedUrlUpdaterService;
+        this.contextUpdaterService = contextUpdaterService;
     }
 
     @GetMapping
@@ -72,7 +72,7 @@ public class Contexts {
         topic.setContext(true);
         URI location = URI.create("/v1/contexts/" + topic.getPublicId());
 
-        cachedUrlUpdaterService.updateContexts(topic);
+        contextUpdaterService.updateContexts(topic);
 
         return ResponseEntity.created(location).build();
     }
@@ -89,6 +89,6 @@ public class Contexts {
         Node topic = nodeRepository.getByPublicId(id);
         topic.setContext(false);
 
-        cachedUrlUpdaterService.updateContexts(topic);
+        contextUpdaterService.updateContexts(topic);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -31,14 +31,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 public abstract class CrudController<T extends DomainEntity> {
     protected TaxonomyRepository<T> repository;
-    protected ContextUpdaterService cachedUrlUpdaterService;
+    protected ContextUpdaterService contextUpdaterService;
 
     private static final Map<Class<?>, String> locations = new HashMap<>();
     private final URNValidator validator = new URNValidator();
 
-    protected CrudController(TaxonomyRepository<T> repository, ContextUpdaterService cachedUrlUpdaterService) {
+    protected CrudController(TaxonomyRepository<T> repository, ContextUpdaterService contextUpdaterService) {
         this.repository = repository;
-        this.cachedUrlUpdaterService = cachedUrlUpdaterService;
+        this.contextUpdaterService = contextUpdaterService;
     }
 
     protected CrudController(TaxonomyRepository<T> repository) {
@@ -67,8 +67,8 @@ public abstract class CrudController<T extends DomainEntity> {
         validator.validate(id, entity);
         command.apply(entity);
 
-        if (entity instanceof Node && cachedUrlUpdaterService != null) {
-            cachedUrlUpdaterService.updateContexts((Node) entity);
+        if (entity instanceof Node && contextUpdaterService != null) {
+            contextUpdaterService.updateContexts((Node) entity);
         }
 
         return entity;
@@ -90,8 +90,8 @@ public abstract class CrudController<T extends DomainEntity> {
             URI location = URI.create(getLocation() + "/" + entity.getPublicId());
             repository.saveAndFlush(entity);
 
-            if (entity instanceof Node && cachedUrlUpdaterService != null) {
-                cachedUrlUpdaterService.updateContexts((Node) entity);
+            if (entity instanceof Node && contextUpdaterService != null) {
+                contextUpdaterService.updateContexts((Node) entity);
             }
 
             return ResponseEntity.created(location).build();

--- a/src/main/java/no/ndla/taxonomy/rest/v1/CrudControllerWithMetadata.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/CrudControllerWithMetadata.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import java.net.URI;
 import no.ndla.taxonomy.domain.DomainEntity;
 import no.ndla.taxonomy.domain.EntityWithMetadata;
+import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.exceptions.NotFoundException;
 import no.ndla.taxonomy.repositories.TaxonomyRepository;
 import no.ndla.taxonomy.service.ContextUpdaterService;
@@ -26,8 +27,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 public abstract class CrudControllerWithMetadata<T extends DomainEntity> extends CrudController<T> {
     protected CrudControllerWithMetadata(
-            TaxonomyRepository<T> repository, ContextUpdaterService cachedUrlUpdaterService) {
-        super(repository, cachedUrlUpdaterService);
+            TaxonomyRepository<T> repository, ContextUpdaterService contextUpdaterService) {
+        super(repository, contextUpdaterService);
     }
 
     @GetMapping("/{id}/metadata")
@@ -51,6 +52,9 @@ public abstract class CrudControllerWithMetadata<T extends DomainEntity> extends
         var entity = repository.findByPublicId(id);
         if (entity instanceof EntityWithMetadata em) {
             var result = em.getMetadata().mergeWith(entityToUpdate);
+            if (entity instanceof Node n && contextUpdaterService != null) {
+                contextUpdaterService.updateContexts(n);
+            }
             return new MetadataDTO(result);
         }
         throw new NotFoundException("Entity", id);

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeConnections.java
@@ -48,8 +48,8 @@ public class NodeConnections extends CrudControllerWithMetadata<NodeConnection> 
             NodeConnectionRepository nodeConnectionRepository,
             NodeConnectionService connectionService,
             RelevanceRepository relevanceRepository,
-            ContextUpdaterService cachedUrlUpdaterService) {
-        super(nodeConnectionRepository, cachedUrlUpdaterService);
+            ContextUpdaterService contextUpdaterService) {
+        super(nodeConnectionRepository, contextUpdaterService);
         this.nodeRepository = nodeRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
         this.connectionService = connectionService;

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -27,7 +27,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
 
         boolean activeContext = node.getCustomFields()
                 .getOrDefault(Constants.SubjectCategory, Constants.Active)
-                .matches(String.format("%s|%s", Constants.Active, Constants.OtherResources));
+                .matches(String.format("%s|%s|%s", Constants.Active, Constants.Beta, Constants.OtherResources));
         // This entity can be root path
         if (node.isContext()) {
             returnedContexts.add(new Context(

--- a/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -27,15 +27,15 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class NodeConnectionServiceImpl implements NodeConnectionService {
     private final NodeConnectionRepository nodeConnectionRepository;
-    private final ContextUpdaterService cachedUrlUpdaterService;
+    private final ContextUpdaterService contextUpdaterService;
     private final NodeRepository nodeRepository;
 
     public NodeConnectionServiceImpl(
             NodeConnectionRepository nodeConnectionRepository,
-            ContextUpdaterService cachedUrlUpdaterService,
+            ContextUpdaterService contextUpdaterService,
             NodeRepository nodeRepository) {
         this.nodeConnectionRepository = nodeConnectionRepository;
-        this.cachedUrlUpdaterService = cachedUrlUpdaterService;
+        this.contextUpdaterService = contextUpdaterService;
         this.nodeRepository = nodeRepository;
     }
 
@@ -65,7 +65,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         updateRank(connection, rank);
         updateRelevance(connection, relevance);
 
-        cachedUrlUpdaterService.updateContexts(child);
+        contextUpdaterService.updateContexts(child);
 
         return connection;
     }
@@ -154,11 +154,11 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
                             .ifPresent(nextConnection -> {
                                 nextConnection.setPrimary(true);
                                 nodeConnectionRepository.saveAndFlush(nextConnection);
-                                nextConnection.getResource().ifPresent(cachedUrlUpdaterService::updateContexts);
+                                nextConnection.getResource().ifPresent(contextUpdaterService::updateContexts);
                             });
                 }
             }
-            cachedUrlUpdaterService.updateContexts(childToDisconnect);
+            contextUpdaterService.updateContexts(childToDisconnect);
         });
 
         nodeConnectionRepository.flush();
@@ -202,7 +202,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         saveConnections(updatedConnectables);
 
         updatedConnectables.forEach(
-                updatedConnectable -> updatedConnectable.getChild().ifPresent(cachedUrlUpdaterService::updateContexts));
+                updatedConnectable -> updatedConnectable.getChild().ifPresent(contextUpdaterService::updateContexts));
 
         if (!setPrimaryTo && !foundNewPrimary.get()) {
             throw new InvalidArgumentServiceException(

--- a/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -176,8 +176,13 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         // Updates all other nodes connected to this parent
         final var foundNewPrimary = new AtomicBoolean(false);
         connectable.getChild().ifPresent(node -> {
-            var theOthers = node.getParentConnections().stream().filter(c -> c != connectable).toList();
-            var hasPrimary = !theOthers.stream().filter(c -> c.isPrimary().orElse(false)).toList().isEmpty();
+            var theOthers = node.getParentConnections().stream()
+                    .filter(c -> c != connectable)
+                    .toList();
+            var hasPrimary = !theOthers.stream()
+                    .filter(c -> c.isPrimary().orElse(false))
+                    .toList()
+                    .isEmpty();
             foundNewPrimary.set(hasPrimary);
             theOthers.forEach(connectable1 -> {
                 if (!setPrimaryTo && !foundNewPrimary.get()) {

--- a/src/test/java/no/ndla/taxonomy/domain/Builder.java
+++ b/src/test/java/no/ndla/taxonomy/domain/Builder.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(propagation = Propagation.MANDATORY)
 public class Builder {
     private final EntityManager entityManager;
-    private final ContextUpdaterService cachedUrlUpdaterService;
+    private final ContextUpdaterService contextUpdaterService;
     private final Map<String, VersionBuilder> versions = new HashMap<>();
     private final Map<String, ResourceTypeBuilder> resourceTypes = new HashMap<>();
     private final Map<String, NodeBuilder> nodes = new HashMap<>();
@@ -29,9 +29,9 @@ public class Builder {
     private final Map<String, UrlMappingBuilder> cachedUrlOldRigBuilders = new HashMap<>();
     private int keyCounter = 0;
 
-    public Builder(EntityManager entityManager, ContextUpdaterService cachedUrlUpdaterService) {
+    public Builder(EntityManager entityManager, ContextUpdaterService contextUpdaterService) {
         this.entityManager = entityManager;
-        this.cachedUrlUpdaterService = cachedUrlUpdaterService;
+        this.contextUpdaterService = contextUpdaterService;
     }
 
     private String createKey() {
@@ -152,7 +152,7 @@ public class Builder {
 
         entityManager.persist(node.node);
 
-        cachedUrlUpdaterService.updateContexts(node.node);
+        contextUpdaterService.updateContexts(node.node);
 
         return node.node;
     }
@@ -317,7 +317,7 @@ public class Builder {
 
         public NodeBuilder nodeType(NodeType nodeType) {
             node.setNodeType(nodeType);
-            cachedUrlUpdaterService.updateContexts(node);
+            contextUpdaterService.updateContexts(node);
             return this;
         }
 
@@ -357,14 +357,14 @@ public class Builder {
         public NodeBuilder publicId(String id) {
             node.setPublicId(URI.create(id));
 
-            cachedUrlUpdaterService.updateContexts(node);
+            contextUpdaterService.updateContexts(node);
             return this;
         }
 
         public NodeBuilder isContext(boolean b) {
             node.setContext(b);
 
-            cachedUrlUpdaterService.updateContexts(node);
+            contextUpdaterService.updateContexts(node);
             return this;
         }
 
@@ -411,7 +411,7 @@ public class Builder {
         public NodeBuilder child(Node child) {
             entityManager.persist(NodeConnection.create(node, child));
 
-            cachedUrlUpdaterService.updateContexts(child);
+            contextUpdaterService.updateContexts(child);
 
             return this;
         }
@@ -454,7 +454,7 @@ public class Builder {
         public NodeBuilder resource(Node resource, boolean primary) {
             entityManager.persist(NodeConnection.create(node, resource, primary));
 
-            cachedUrlUpdaterService.updateContexts(resource);
+            contextUpdaterService.updateContexts(resource);
 
             return this;
         }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/ContextsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/ContextsTest.java
@@ -23,7 +23,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 
 public class ContextsTest extends RestTest {
     @Autowired
-    private ContextUpdaterService cachedUrlUpdaterService;
+    private ContextUpdaterService contextUpdaterService;
 
     @BeforeEach
     void cleanDatabase() {
@@ -124,7 +124,7 @@ public class ContextsTest extends RestTest {
         topic.setContext(true);
         nodeRepository.saveAndFlush(topic);
 
-        cachedUrlUpdaterService.updateContexts(topic);
+        contextUpdaterService.updateContexts(topic);
 
         MockHttpServletResponse response = testUtils.getResource("/v1/topics/urn:topic:1");
         final var topicIndexDocument = testUtils.getObject(NodeDTO.class, response);


### PR DESCRIPTION
Dersom vi i en mellomstate ikkje har primary connections til en node, vil denne endringa plukke en tilfeldig connection som vil være primary. Dette kan skje dersom du gjør fleire endringer i taksonomiblokka samtidig, og du ikkje er sikker på rekkefølgen operasjonene skjer i.
Om du har fleire operasjoner samtidig i taksonomiblokk i ed vil sluttresultatet bli korrekt fordi minst en av dei vil ha primary=true og då vil den koblinga "vinne".

I tillegg: Kommende fag skal også kunne søkes opp, og endring av metadata oppdaterer kontekster.