### PR TITLE
Adding db-constraint to prevent resource to have same content_uri

### DIFF
--- a/src/main/java/no/ndla/taxonomy/migration/CleanUpDuplicateResourcesSqlChange.java
+++ b/src/main/java/no/ndla/taxonomy/migration/CleanUpDuplicateResourcesSqlChange.java
@@ -1,0 +1,141 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2023 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.migration;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import liquibase.change.custom.CustomSqlChange;
+import liquibase.database.Database;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.CustomChangeException;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.SetupException;
+import liquibase.exception.ValidationErrors;
+import liquibase.resource.ResourceAccessor;
+import liquibase.statement.SqlStatement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CleanUpDuplicateResourcesSqlChange implements CustomSqlChange {
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private JdbcConnection connection;
+
+    @Override
+    public SqlStatement[] generateStatements(Database database) throws CustomChangeException {
+        connection = (JdbcConnection) database.getConnection();
+
+        try {
+            connection.setAutoCommit(false);
+        } catch (DatabaseException e) {
+            throw new CustomChangeException("Error starting transaction. No changes made. Error:" + e.getMessage(), e);
+        }
+
+        try {
+            try (var contentUrisSharedByMultipleResources = connection.prepareStatement(
+                    "select content_uri from (select count(id) as antall, content_uri from node where node_type = 'RESOURCE' group by content_uri order by antall desc) as duplicates where antall > 1")) {
+                final var resourceListQuery = contentUrisSharedByMultipleResources.executeQuery();
+
+                while (resourceListQuery.next()) {
+                    final var contentUri = resourceListQuery.getString(1);
+
+                    if (contentUri != null) {
+                        // ignoring resurces with null in contenturi
+                        cleanUpResources(contentUri);
+                    }
+                }
+            } catch (DatabaseException | SQLException exception) {
+                throw new CustomChangeException(exception);
+            }
+        } catch (RuntimeException | CustomChangeException exception) {
+            try {
+                connection.rollback();
+            } catch (DatabaseException ignored) {
+            }
+
+            throw exception;
+        }
+
+        return new SqlStatement[0];
+    }
+
+    private void cleanUpResources(String contentUri) throws DatabaseException, SQLException {
+        logger.info(String.format("Cleaning up nodes with content_uri %s", contentUri));
+        ResultSet result = connection
+                .prepareStatement(String.format("SELECT id from node where content_uri = '%s'", contentUri))
+                .executeQuery();
+        // First one wins
+        result.next();
+        final var winning = result.getInt(1);
+        // Delete the others
+        while (result.next()) {
+            final var id = result.getInt(1);
+            // reconnect winning resource in node_connection to replace the one to delete
+            reconnectConnections(winning, id);
+            // delete remaining connections
+            connection
+                    .prepareStatement(String.format("delete from node_connection where child_id = %s", id))
+                    .executeUpdate();
+            // delete the node
+            connection
+                    .prepareStatement(String.format("delete from resource_resource_type where resource_id = %s", id))
+                    .executeUpdate();
+            connection
+                    .prepareStatement(String.format("delete from node where id = %s", id))
+                    .executeUpdate();
+        }
+    }
+
+    private void reconnectConnections(int winning, int loosing) throws DatabaseException, SQLException {
+        // Get all parents to winning node
+        ResultSet parents = connection
+                .prepareStatement(String.format("select parent_id from node_connection where child_id = %s", winning))
+                .executeQuery();
+        if (parents != null) {
+            while (parents.next()) {
+                final var parent = parents.getInt(1);
+                // Check if loosing node has same parent as winning node
+                ResultSet connections = connection
+                        .prepareStatement(String.format(
+                                "select count(*) from node_connection where parent_id = %s and child_id = %s",
+                                parent, loosing))
+                        .executeQuery();
+                connections.next();
+                final var count = connections.getInt(1);
+                if (count == 0) {
+                    // No shared parent, put winning node into the position of the loosing node
+                    connection
+                            .prepareStatement(String.format(
+                                    "update node_connection set child_id = %s where child_id = %s", winning, loosing))
+                            .executeUpdate();
+                } else {
+                    // Shared parents, so it's safe to delete the connection to the loosing node
+                    connection
+                            .prepareStatement(String.format("delete from node_connection where child_id = %s", loosing))
+                            .executeUpdate();
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getConfirmationMessage() {
+        return "Cleaned up all duplicate resources";
+    }
+
+    @Override
+    public void setUp() throws SetupException {}
+
+    @Override
+    public void setFileOpener(ResourceAccessor resourceAccessor) {}
+
+    @Override
+    public ValidationErrors validate(Database database) {
+        return null;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -82,7 +82,7 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
     @Override
     public NodeConnection connectParentChild(
             Node parent, Node child, Relevance relevance, Integer rank, Optional<Boolean> isPrimary) {
-        if (child.getParentConnections().size() > 0) {
+        if (!child.getParentConnections().isEmpty()) {
             if (child.getNodeType() == NodeType.TOPIC) throw new DuplicateConnectionException();
 
             var alreadyConnectedResource = parent.getResourceChildren().stream()

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1409,4 +1409,17 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="20230823 Add constraint to avoid same content_uri for resources" author="Gunnar Velle">
+        <sql>CREATE EXTENSION IF NOT EXISTS "btree_gist"</sql>
+        <sql>
+            ALTER TABLE node
+            ADD CONSTRAINT unique_content_uri_for_resource
+            EXCLUDE USING GIST (
+                node_type WITH =,
+                content_uri WITH =
+            )
+            WHERE (node_type = 'RESOURCE');
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1409,6 +1409,10 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="20230823 Clean up duplicate resources" author="Gunnar Velle">
+        <customChange class="no.ndla.taxonomy.migration.CleanUpDuplicateResourcesSqlChange"/>
+    </changeSet>
+
     <changeSet id="20230823 Add constraint to avoid same content_uri for resources" author="Gunnar Velle">
         <sql>CREATE EXTENSION IF NOT EXISTS "btree_gist"</sql>
         <sql>

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
@@ -116,7 +116,7 @@ public class NodesTest extends RestTest {
     }
 
     @Test
-    public void can_get_nodes_by_contextId() throws Exception {
+    public void can_get_nodes_by_contextId() {
         Node resource = builder.node(NodeType.RESOURCE, r -> r.name("Resource"));
         builder.node(
                 NodeType.SUBJECT, s -> s.isContext(true).name("Basic science").child(NodeType.TOPIC, t -> {
@@ -218,7 +218,7 @@ public class NodesTest extends RestTest {
 
         assertAllTrue(nodes, t -> t.getMetadata() != null);
         assertAllTrue(nodes, t -> t.getMetadata().isVisible());
-        assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().size() == 0);
+        assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().isEmpty());
     }
 
     @Test
@@ -312,7 +312,7 @@ public class NodesTest extends RestTest {
 
             assertAllTrue(nodes, t -> t.getMetadata() != null);
             assertAllTrue(nodes, t -> t.getMetadata().isVisible());
-            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().size() == 0);
+            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().isEmpty());
         }
     }
 
@@ -340,7 +340,7 @@ public class NodesTest extends RestTest {
 
             assertAllTrue(nodes, t -> t.getMetadata() != null);
             assertAllTrue(nodes, t -> t.getMetadata().isVisible());
-            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().size() == 0);
+            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().isEmpty());
         }
         {
             var response = testUtils.getResource(
@@ -358,7 +358,7 @@ public class NodesTest extends RestTest {
 
             assertAllTrue(nodes, t -> t.getMetadata() != null);
             assertAllTrue(nodes, t -> t.getMetadata().isVisible());
-            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().size() == 0);
+            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().isEmpty());
         }
         {
             var response = testUtils.getResource(
@@ -374,7 +374,7 @@ public class NodesTest extends RestTest {
 
             assertAllTrue(nodes, t -> t.getMetadata() != null);
             assertAllTrue(nodes, t -> t.getMetadata().isVisible());
-            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().size() == 0);
+            assertAllTrue(nodes, t -> t.getMetadata().getGrepCodes().isEmpty());
         }
     }
 
@@ -520,7 +520,7 @@ public class NodesTest extends RestTest {
         final var connections = testUtils.getObject(ConnectionDTO[].class, response);
 
         assertEquals(3, connections.length, "Correct number of connections");
-        assertAllTrue(connections, c -> c.getPaths().size() > 0); // all connections have at least one path
+        assertAllTrue(connections, c -> !c.getPaths().isEmpty()); // all connections have at least one path
 
         connectionsHaveCorrectTypes(connections);
     }
@@ -559,7 +559,7 @@ public class NodesTest extends RestTest {
         assertAllTrue(subtopics, subtopic -> subtopic.getMetadata() != null);
         assertAllTrue(subtopics, subtopic -> subtopic.getMetadata().isVisible());
         assertAllTrue(
-                subtopics, subtopic -> subtopic.getMetadata().getGrepCodes().size() == 0);
+                subtopics, subtopic -> subtopic.getMetadata().getGrepCodes().isEmpty());
     }
 
     @Test
@@ -658,6 +658,29 @@ public class NodesTest extends RestTest {
 
         Node node = nodeRepository.getByPublicId(createNodeCommand.getPublicId());
         assertEquals("trigonometry", node.getName());
+    }
+
+    @Test
+    void creating_node_with_content_uri_is_handled_correct() throws Exception {
+        final var createTopic = new NodePostPut() {
+            {
+                nodeType = NodeType.TOPIC;
+                name = Optional.of("topic");
+                contentUri = Optional.of(URI.create("urn:article:1"));
+            }
+        };
+        final var createResource = new NodePostPut() {
+            {
+                nodeType = NodeType.RESOURCE;
+                name = Optional.of("resource");
+                contentUri = Optional.of(URI.create("urn:article:2"));
+            }
+        };
+
+        testUtils.createResource("/v1/nodes", createTopic, status().isCreated());
+        testUtils.createResource("/v1/nodes", createTopic, status().isCreated());
+        testUtils.createResource("/v1/nodes", createResource, status().isCreated());
+        testUtils.createResource("/v1/nodes", createResource, status().isConflict());
     }
 
     @Test


### PR DESCRIPTION
NDLANO/Issues##3526

~Krever en manuell opprydding i taksonomibasene før deploy for at denne skal kunne deployes.~ har laga en migrering som gjør jobben.

Gjør det slik at alle noder av type RESOURCE _må_ ha unik contentUri.