### PR TITLE
Takes parent into consideration when selecting context.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -160,8 +160,13 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
         var ids = nodeRepository.findIdsPaginated(PageRequest.of(page.get() - 1, pageSize.get()));
         var results = nodeRepository.findByIds(ids.getContent());
         var contents = results.stream()
-                .map(node ->
-                        new NodeDTO(Optional.empty(), node, language.orElse("nb"), Optional.empty(), includeContexts))
+                .map(node -> new NodeDTO(
+                        Optional.empty(),
+                        Optional.empty(),
+                        node,
+                        language.orElse("nb"),
+                        Optional.empty(),
+                        includeContexts))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -131,7 +131,12 @@ public class Resources extends CrudControllerWithMetadata<Node> {
         var results = nodeRepository.findByIds(ids.getContent());
         var contents = results.stream()
                 .map(node -> new NodeDTO(
-                        Optional.empty(), node, language.orElse("nb"), Optional.empty(), Optional.of(false)))
+                        Optional.empty(),
+                        Optional.empty(),
+                        node,
+                        language.orElse("nb"),
+                        Optional.empty(),
+                        Optional.of(false)))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -129,7 +129,12 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
         var results = nodeRepository.findByIds(ids.getContent());
         var contents = results.stream()
                 .map(node -> new NodeDTO(
-                        Optional.empty(), node, language.orElse("nb"), Optional.empty(), Optional.of(false)))
+                        Optional.empty(),
+                        Optional.empty(),
+                        node,
+                        language.orElse("nb"),
+                        Optional.empty(),
+                        Optional.of(false)))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -115,7 +115,12 @@ public class Topics extends CrudControllerWithMetadata<Node> {
         var results = nodeRepository.findByIds(ids.getContent());
         var contents = results.stream()
                 .map(node -> new NodeDTO(
-                        Optional.empty(), node, language.orElse("nb"), Optional.empty(), Optional.of(false)))
+                        Optional.empty(),
+                        Optional.empty(),
+                        node,
+                        language.orElse("nb"),
+                        Optional.empty(),
+                        Optional.of(false)))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -132,8 +132,13 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                 .forEach(idChunk -> {
                     final var nodes = nodeRepository.findByIds(idChunk);
                     var dtos = nodes.stream()
-                            .map(node ->
-                                    new NodeDTO(Optional.empty(), node, language.get(), contextId, includeContexts))
+                            .map(node -> new NodeDTO(
+                                    Optional.empty(),
+                                    Optional.empty(),
+                                    node,
+                                    language.get(),
+                                    contextId,
+                                    includeContexts))
                             .toList();
                     listToReturn.addAll(dtos);
                 });
@@ -170,7 +175,12 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
     public NodeDTO getNode(URI publicId, Optional<String> language, Optional<Boolean> includeContexts) {
         var node = getNode(publicId);
         return new NodeDTO(
-                Optional.empty(), node, language.orElse(Constants.DefaultLanguage), Optional.empty(), includeContexts);
+                Optional.empty(),
+                Optional.empty(),
+                node,
+                language.orElse(Constants.DefaultLanguage),
+                Optional.empty(),
+                includeContexts);
     }
 
     public Node getNode(URI publicId) {
@@ -285,7 +295,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
 
     @Override
     public NodeDTO createDTO(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        return new NodeDTO(Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
+        return new NodeDTO(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
     }
 
     public SearchResultDTO<NodeDTO> searchByNodeType(

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -45,6 +45,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
             Optional<Node> root, NodeConnection nodeConnection, String language, Optional<Boolean> includeContexts) {
         super(
                 root,
+                nodeConnection.getParent(),
                 nodeConnection.getChild().orElseThrow(() -> new NotFoundException("Child was not found")),
                 language,
                 Optional.empty(),
@@ -68,7 +69,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
      * Special constructor used to get parents for resource/full
      */
     public NodeChildDTO(Node parent, NodeConnection nodeConnection, String language) {
-        super(Optional.empty(), parent, language, Optional.empty(), Optional.of(false));
+        super(Optional.empty(), nodeConnection.getParent(), parent, language, Optional.empty(), Optional.of(false));
 
         this.rank = nodeConnection.getRank();
         this.connectionId = nodeConnection.getPublicId();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -78,6 +78,7 @@ public class NodeDTO {
 
     public NodeDTO(
             Optional<Node> root,
+            Optional<Node> parent,
             Node entity,
             String languageCode,
             Optional<String> contextId,
@@ -111,7 +112,7 @@ public class NodeDTO {
 
         this.nodeType = entity.getNodeType();
 
-        Optional<Context> context = entity.pickContext(contextId, root);
+        Optional<Context> context = entity.pickContext(contextId, parent, root);
         context.ifPresent(ctx -> {
             this.path = ctx.path();
             // TODO: this changes the content in context breadcrumbs

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -29,7 +29,7 @@ public class NodeWithParents extends NodeDTO {
     public NodeWithParents() {}
 
     public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        super(Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
+        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
 
         node.getParentConnections().stream()
                 .map(nodeResource -> {


### PR DESCRIPTION
Plukker korrekt path der parent er inkludert. Gammel kode ville returnere samme path for to noder som låg under samme rot, med like lang vei til toppen. 
Har lagt til et par ekstra tester for å sjekke at ting oppfører seg som dei skal.