### PR TITLE
Add param to filter out programme contexts when fetching taxonomy

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -85,7 +85,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 Optional.empty(),
                 metadataFilters,
-                Optional.of(false));
+                Optional.of(false),
+                false);
     }
 
     @Deprecated
@@ -108,7 +109,15 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris) {
         return nodeService.searchByNodeType(
-                query, ids, contentUris, language, Optional.of(false), pageSize, page, Optional.of(NodeType.RESOURCE));
+                query,
+                ids,
+                contentUris,
+                language,
+                Optional.of(false),
+                false,
+                pageSize,
+                page,
+                Optional.of(NodeType.RESOURCE));
     }
 
     @Deprecated
@@ -136,7 +145,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                         node,
                         language.orElse("nb"),
                         Optional.empty(),
-                        Optional.of(false)))
+                        Optional.of(false),
+                        false))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -82,7 +82,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 Optional.empty(),
                 metadataFilters,
-                Optional.of(false));
+                Optional.of(false),
+                false);
     }
 
     @Deprecated
@@ -106,7 +107,15 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                     Optional<List<String>> contentUris) {
 
         return nodeService.searchByNodeType(
-                query, ids, contentUris, language, Optional.of(false), pageSize, page, Optional.of(NodeType.SUBJECT));
+                query,
+                ids,
+                contentUris,
+                language,
+                Optional.of(false),
+                false,
+                pageSize,
+                page,
+                Optional.of(NodeType.SUBJECT));
     }
 
     @Deprecated
@@ -134,7 +143,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         node,
                         language.orElse("nb"),
                         Optional.empty(),
-                        Optional.of(false)))
+                        Optional.of(false),
+                        false))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }
@@ -240,7 +250,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         Optional.of(subject),
                         nodeConnection,
                         language.orElse(Constants.DefaultLanguage),
-                        Optional.of(false)))
+                        Optional.of(false),
+                        false))
                 .forEach(returnList::add);
 
         var filtered = returnList.stream()

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -70,7 +70,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 Optional.empty(),
                 metadataFilters,
-                Optional.of(false));
+                Optional.of(false),
+                false);
     }
 
     @Deprecated
@@ -93,7 +94,15 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris) {
         return nodeService.searchByNodeType(
-                query, ids, contentUris, language, Optional.of(false), pageSize, page, Optional.of(NodeType.TOPIC));
+                query,
+                ids,
+                contentUris,
+                language,
+                Optional.of(false),
+                false,
+                pageSize,
+                page,
+                Optional.of(NodeType.TOPIC));
     }
 
     @Deprecated
@@ -120,7 +129,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                         node,
                         language.orElse("nb"),
                         Optional.empty(),
-                        Optional.of(false)))
+                        Optional.of(false),
+                        false))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -114,7 +114,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             Optional<Boolean> isRoot,
             Optional<Boolean> isContext,
             MetadataFilters metadataFilters,
-            Optional<Boolean> includeContexts) {
+            Optional<Boolean> includeContexts,
+            boolean filterProgrammes) {
         final List<NodeDTO> listToReturn = new ArrayList<>();
         var ids = nodeRepository.findIdsFiltered(
                 nodeType,
@@ -138,7 +139,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                                     node,
                                     language.get(),
                                     contextId,
-                                    includeContexts))
+                                    includeContexts,
+                                    filterProgrammes))
                             .toList();
                     listToReturn.addAll(dtos);
                 });
@@ -166,7 +168,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
 
         final var wrappedList = childConnections.stream()
                 .map(nodeConnection ->
-                        new NodeChildDTO(Optional.of(node), nodeConnection, languageCode, Optional.of(false)))
+                        new NodeChildDTO(Optional.of(node), nodeConnection, languageCode, Optional.of(false), false))
                 .toList();
 
         return topicTreeSorter.sortList(wrappedList);
@@ -180,7 +182,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                 node,
                 language.orElse(Constants.DefaultLanguage),
                 Optional.empty(),
-                includeContexts);
+                includeContexts,
+                false);
     }
 
     public Node getNode(URI publicId) {
@@ -283,7 +286,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                             Optional.of(root),
                             nodeConnection,
                             languageCode.orElse(Constants.DefaultLanguage),
-                            includeContexts);
+                            includeContexts,
+                            false);
                 })
                 .collect(toList());
     }
@@ -294,8 +298,16 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
     }
 
     @Override
-    public NodeDTO createDTO(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        return new NodeDTO(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
+    public NodeDTO createDTO(
+            Node node, String languageCode, Optional<Boolean> includeContexts, boolean filterProgrammes) {
+        return new NodeDTO(
+                Optional.empty(),
+                Optional.empty(),
+                node,
+                languageCode,
+                Optional.empty(),
+                includeContexts,
+                filterProgrammes);
     }
 
     public SearchResultDTO<NodeDTO> searchByNodeType(
@@ -304,12 +316,13 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             Optional<List<String>> contentUris,
             Optional<String> language,
             Optional<Boolean> includeContexts,
+            boolean filterProgrammes,
             int pageSize,
             int page,
             Optional<NodeType> nodeType) {
         Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasNodeType(nt))));
         return SearchService.super.search(
-                query, ids, contentUris, language, includeContexts, pageSize, page, nodeSpecLambda);
+                query, ids, contentUris, language, includeContexts, filterProgrammes, pageSize, page, nodeSpecLambda);
     }
 
     @Transactional

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -27,7 +27,7 @@ interface ExtraSpecification<T> {
 public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends TaxonomyRepository<DOMAIN>> {
     REPO getRepository();
 
-    DTO createDTO(DOMAIN domain, String languageCode, Optional<Boolean> includeContexts);
+    DTO createDTO(DOMAIN domain, String languageCode, Optional<Boolean> includeContexts, boolean filterProgrammes);
 
     private Specification<DOMAIN> base() {
         return (root, query, criteriaBuilder) -> criteriaBuilder.isNotNull(root.get("id"));
@@ -54,7 +54,7 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
             Optional<Boolean> includeContext,
             int pageSize,
             int page) {
-        return search(query, ids, contentUris, language, includeContext, pageSize, page, Optional.empty());
+        return search(query, ids, contentUris, language, includeContext, false, pageSize, page, Optional.empty());
     }
 
     default SearchResultDTO<DTO> search(
@@ -63,6 +63,7 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
             Optional<List<String>> contentUris,
             Optional<String> language,
             Optional<Boolean> includeContexts,
+            boolean filterProgrammes,
             int pageSize,
             int page,
             Optional<ExtraSpecification<DOMAIN>> applySpecLambda) {
@@ -111,7 +112,7 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
 
         var languageCode = language.orElse("");
         var dtos = fetched.stream()
-                .map(r -> createDTO(r, languageCode, includeContexts))
+                .map(r -> createDTO(r, languageCode, includeContexts, filterProgrammes))
                 .collect(Collectors.toList());
 
         return new SearchResultDTO<>(fetched.getTotalElements(), page, pageSize, dtos);

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -42,14 +42,19 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
     private Optional<URI> relevanceId;
 
     public NodeChildDTO(
-            Optional<Node> root, NodeConnection nodeConnection, String language, Optional<Boolean> includeContexts) {
+            Optional<Node> root,
+            NodeConnection nodeConnection,
+            String language,
+            Optional<Boolean> includeContexts,
+            boolean filterProgrammes) {
         super(
                 root,
                 nodeConnection.getParent(),
                 nodeConnection.getChild().orElseThrow(() -> new NotFoundException("Child was not found")),
                 language,
                 Optional.empty(),
-                includeContexts);
+                includeContexts,
+                filterProgrammes);
 
         // This must be enabled when ed is updated to update metadata for connections.
         // this.metadata = new MetadataDto(nodeConnection.getMetadata());
@@ -69,7 +74,14 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
      * Special constructor used to get parents for resource/full
      */
     public NodeChildDTO(Node parent, NodeConnection nodeConnection, String language) {
-        super(Optional.empty(), nodeConnection.getParent(), parent, language, Optional.empty(), Optional.of(false));
+        super(
+                Optional.empty(),
+                nodeConnection.getParent(),
+                parent,
+                language,
+                Optional.empty(),
+                Optional.of(false),
+                false);
 
         this.rank = nodeConnection.getRank();
         this.connectionId = nodeConnection.getPublicId();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -82,7 +82,8 @@ public class NodeDTO {
             Node entity,
             String languageCode,
             Optional<String> contextId,
-            Optional<Boolean> includeContexts) {
+            Optional<Boolean> includeContexts,
+            boolean filterProgrammes) {
         this.id = entity.getPublicId();
         this.contentUri = Optional.ofNullable(entity.getContentUri());
 
@@ -130,6 +131,7 @@ public class NodeDTO {
             }
             LanguageField<String> finalRelevanceName = relevanceName;
             this.contexts = entity.getContexts().stream()
+                    .filter(ctx -> !filterProgrammes || !ctx.rootId().contains(NodeType.PROGRAMME.name()))
                     .map(ctx -> {
                         return new TaxonomyContextDTO(
                                 entity.getPublicId(),

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -29,7 +29,7 @@ public class NodeWithParents extends NodeDTO {
     public NodeWithParents() {}
 
     public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts);
+        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts, false);
 
         node.getParentConnections().stream()
                 .map(nodeResource -> {

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -114,6 +114,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 10,
                 1,
                 Optional.of(NodeType.SUBJECT));
@@ -124,6 +125,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 10,
                 1,
                 Optional.of(NodeType.TOPIC));
@@ -133,6 +135,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                false,
                 10,
                 1,
                 Optional.empty());


### PR DESCRIPTION
Legger på en parameter som gjør det mulig å ikkje hente ut kontekster med programfag på toppen,