### PR TITLE
Update all contexts on put

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeConnectionServiceImpl.java
@@ -243,6 +243,8 @@ public class NodeConnectionServiceImpl implements NodeConnectionService {
         newRank.ifPresent(integer -> updateRank(nodeConnection, integer));
         isPrimary.ifPresent(primary -> updatePrimaryConnection(nodeConnection, primary));
         updateRelevance(nodeConnection, relevance);
+
+        nodeConnection.getChild().ifPresent(contextUpdaterService::updateContexts);
     }
 
     @Override


### PR DESCRIPTION
Passer på å oppdatere contexts ved oppdatering av nodeconnection.

Dersom nodeconnection som oppdateres også har endring av primary vil funksjonen updatePrimaryConnection regenere kontekstene, men i mange tilfeller skjer ikkje det. Derfår må den eksplisitt oppdateres.