### PR TITLE
Return language for name. Add field for stored name.

### DIFF
--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeTranslationsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeTranslationsTest.java
@@ -35,6 +35,7 @@ public class NodeTranslationsTest extends RestTest {
         assertEquals(2, nodes.length);
         assertAnyTrue(nodes, s -> s.getName().equals("Trigonometri"));
         assertAnyTrue(nodes, s -> s.getName().equals("Integrasjon"));
+        assertAllTrue(nodes, s -> s.getLanguage().equals("nb"));
     }
 
     @Test
@@ -47,14 +48,25 @@ public class NodeTranslationsTest extends RestTest {
     }
 
     @Test
-    public void fallback_to_default_language() throws Exception {
+    public void fallback_to_default_language_if_no_translation() throws Exception {
         URI id = builder.node(NodeType.TOPIC, t -> t.name("Trigonometry")).getPublicId();
         final var topic = getNode(id, "XX");
         assertEquals("Trigonometry", topic.getName());
+        assertEquals("nb", topic.getLanguage());
     }
 
     @Test
-    public void can_get_default_language() throws Exception {
+    public void fallback_to_translated_name() throws Exception {
+        URI id = builder.node(NodeType.TOPIC, t -> t.name("Trignometri").translation("Trignometry", "en"))
+                .getPublicId();
+        final var topic = getNode(id, "nb");
+        assertEquals("Trignometry", topic.getName());
+        assertEquals("en", topic.getLanguage());
+        assertEquals("Trignometri", topic.getBaseName());
+    }
+
+    @Test
+    public void defaults_to_default_language() throws Exception {
         URI id = builder.node(
                         NodeType.TOPIC, t -> t.name("Trigonometry").translation("nb", l -> l.name("Trigonometri")))
                 .getPublicId();
@@ -166,7 +178,7 @@ public class NodeTranslationsTest extends RestTest {
     }
 
     @Test
-    public void can_get_resources_for_a_node_without_childrem_resources_with_translation() throws Exception {
+    public void can_get_resources_for_a_node_without_child_resources_with_translation() throws Exception {
         builder.resourceType("article", rt -> rt.name("Article").translation("nb", tr -> tr.name("Artikkel")));
 
         builder.node(NodeType.SUBJECT, s -> s.isContext(true).child(NodeType.TOPIC, t -> t.publicId("urn:topic:1")

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -7,6 +7,7 @@
 
 package no.ndla.taxonomy.service;
 
+import static no.ndla.taxonomy.TestUtils.assertAnyTrue;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -205,8 +206,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         var result = nodeService.search(
                 Optional.empty(), Optional.empty(), Optional.of(idList), Optional.empty(), Optional.empty(), 10, 1);
 
-        assertEquals(result.getResults().get(0).getId(), new URI("urn:topic:1"));
-        assertEquals(result.getResults().get(1).getId(), new URI("urn:topic:4"));
+        assertAnyTrue(result.getResults(), res -> res.getId().equals(URI.create("urn:topic:1")));
+        assertAnyTrue(result.getResults(), res -> res.getId().equals(URI.create("urn:topic:4")));
         assertEquals(result.getTotalCount(), 2);
     }
 }

--- a/typescript/taxonomy-api.ts
+++ b/typescript/taxonomy-api.ts
@@ -24,6 +24,7 @@ export interface Metadata {
 }
 
 export interface Node {
+    _name: string;
     breadcrumbs: string[];
     contentUri?: string;
     /**
@@ -32,6 +33,7 @@ export interface Node {
     contextId?: string;
     contexts: TaxonomyContext[];
     id: string;
+    language: string;
     metadata: Metadata;
     name: string;
     /**

--- a/typescript/taxonomy-api.ts
+++ b/typescript/taxonomy-api.ts
@@ -24,7 +24,7 @@ export interface Metadata {
 }
 
 export interface Node {
-    _name: string;
+    baseName: string;
     breadcrumbs: string[];
     contentUri?: string;
     /**


### PR DESCRIPTION
Endrer oppførsel ved henting av navn. No hentes alltid baseName som er det som noden blei oppretta med. Name vil alltid returnere oversatt tekst gitt at det finnes. Dersom det finnes kun en oversettelse så vil denne returneres, samt at nytt felt language viser kva språk det er henta tekst på.