### PR TITLE
Support passing multiple node types to `/nodes/search`

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -137,7 +137,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris,
             @Parameter(description = "Filter by nodeType") @RequestParam(value = "nodeType", required = false)
-                    Optional<NodeType> nodeType,
+                    Optional<List<NodeType>> nodeType,
             @Parameter(description = "Include all contexts") @RequestParam(value = "includeContexts", required = false)
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -117,7 +117,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(NodeType.RESOURCE));
+                Optional.of(List.of(NodeType.RESOURCE)));
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -115,7 +115,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(NodeType.SUBJECT));
+                Optional.of(List.of(NodeType.SUBJECT)));
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -102,7 +102,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(NodeType.TOPIC));
+                Optional.of(List.of(NodeType.TOPIC)));
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -102,8 +102,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
         nodeRepository.flush();
     }
 
-    public Specification<Node> nodeHasNodeType(NodeType nodeType) {
-        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(root.get("nodeType"), nodeType);
+    public Specification<Node> nodeHasOneOfNodeType(List<NodeType> nodeType) {
+        return (root, query, builder) -> root.get("nodeType").in(nodeType);
     }
 
     public List<NodeDTO> getNodesByType(
@@ -319,8 +319,8 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             boolean filterProgrammes,
             int pageSize,
             int page,
-            Optional<NodeType> nodeType) {
-        Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasNodeType(nt))));
+            Optional<List<NodeType>> nodeType) {
+        Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasOneOfNodeType(nt))));
         return SearchService.super.search(
                 query, ids, contentUris, language, includeContexts, filterProgrammes, pageSize, page, nodeSpecLambda);
     }

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.*;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import no.ndla.taxonomy.domain.*;
@@ -118,7 +119,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
-                Optional.of(NodeType.SUBJECT));
+                Optional.of(List.of(NodeType.SUBJECT)));
 
         var topics = nodeService.searchByNodeType(
                 Optional.empty(),
@@ -129,7 +130,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
-                Optional.of(NodeType.TOPIC));
+                Optional.of(List.of(NodeType.TOPIC)));
         var all = nodeService.searchByNodeType(
                 Optional.empty(),
                 Optional.empty(),


### PR DESCRIPTION
Håper jeg skal slippe unna med én måte å hente taksonomi på under indeksering i search-api.