### PR TITLE
Retrofit database migrations

### DIFF
--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1186,10 +1186,20 @@
     </changeSet>
 
     <changeSet id="20230208 Move translations to separate column for relevances" author="Jonas Natten">
+        <validCheckSum>8:895d7f163967dd6d6f3f65fb2547addc</validCheckSum>
         <addColumn tableName="relevance">
             <column name="translations" type="jsonb" />
         </addColumn>
-        <!-- There are no translations in the database for now, so lets not bother with a migration that does nothing -->
+        <sql>
+            UPDATE relevance r
+            SET translations=(
+                SELECT json_agg(trans) FROM (
+                    SELECT ((js->'f1')::jsonb-'id'-'relevance_id'-'language_code'|| jsonb_build_object('languageCode', js->'f1'->'language_code')) trans FROM (SELECT row_to_json(row(rt)) AS js FROM relevance tr
+                    INNER JOIN relevance_translation rt ON rt.relevance_id = tr.id
+                    WHERE rt.id = r.id) AS _
+                ) AS _
+            )
+        </sql>
         <sql>
             UPDATE relevance
             SET translations='[]'

--- a/src/main/resources/db-migrate-from-flyway.xml
+++ b/src/main/resources/db-migrate-from-flyway.xml
@@ -89,6 +89,7 @@
                                  referencedColumnNames="id"/>
     </changeSet>
     <changeSet id="20190605 v7 create resource_type table" author="Migrated From Flyway">
+        <validCheckSum>8:d30608305a6da4c8bb4741a570417e33</validCheckSum>
         <createTable tableName="resource_type">
             <column name="id" type="serial">
                 <constraints primaryKey="true"/>
@@ -102,6 +103,35 @@
             </column>
             <column name="name" type="varchar(255)"/>
         </createTable>
+        <sql>
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (1, null, 'urn:resourcetype:learningPath', 'Læringssti');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (2, null, 'urn:resourcetype:subjectMaterial', 'Fagstoff');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (3, 2, 'urn:resourcetype:academicArticle', 'Fagartikkel');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (4, 2, 'urn:resourcetype:guidance', 'Veiledning');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (5, null, 'urn:resourcetype:tasksAndActivities', 'Oppgaver og aktiviteter');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (6, 5, 'urn:resourcetype:task', 'Oppgave');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (7, 2, 'urn:resourcetype:movieAndClip', 'Film og filmklipp');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (8, 2, 'urn:resourcetype:lectureAndPresentation', 'Forelesning og presentasjon');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (9, 2, 'urn:resourcetype:simulation', 'Simulering');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (10, 5, 'urn:resourcetype:exercise', 'Øvelse');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (11, null, 'urn:resourcetype:reviewResource', 'Vurderingsressurs');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (12, 11, 'urn:resourcetype:selfEvaluation', 'Egenvurdering');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (14, 5, 'urn:resourcetype:game', 'Spill');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (15, 5, 'urn:resourcetype:workAssignment', 'Arbeidsoppdrag');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (16, 2, 'urn:resourcetype:dictionary', 'Oppslagsverk og ordliste');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (17, 2, 'urn:resourcetype:toolAndTemplate', 'Verktøy og mal');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (18, null, 'urn:resourcetype:SourceMaterial', 'Kildemateriale');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (19, 18, 'urn:resourcetype:featureFilm', 'Spillefilm');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (20, 18, 'urn:resourcetype:shortFilm', 'Kortfilm');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (24, 18, 'urn:resourcetype:historicalMaterial', 'Historisk materiale');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (25, 18, 'urn:resourcetype:literaryText', 'Litterære tekster');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (27, 18, 'urn:resourcetype:soundRecording', 'Lydopptak');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (28, 2, 'urn:resourcetype:experiment', 'Forsøk');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (32, 18, 'urn:resourcetype:filmClip', 'Filmklipp');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (33, 18, 'urn:resourcetype:series', 'Serier');
+            INSERT INTO resource_type (id, parent_id, public_id, name) VALUES (34, 18, 'urn:resourcetype:documentary', 'Dokumentarfilm');
+            ALTER SEQUENCE resource_type_id_seq RESTART WITH 35;
+        </sql>
     </changeSet>
     <changeSet id="20190605 v8 create resource_resource_type table" author="Migrated From Flyway">
         <createTable tableName="resource_resource_type">
@@ -124,6 +154,7 @@
         </addColumn>
     </changeSet>
     <changeSet id="20190605 v10 language" author="Migrated From Flyway">
+        <validCheckSum>8:bfa1be1fac786e4a73e2b21b075bdb43</validCheckSum>
         <createTable tableName="subject_translation">
             <column name="id" type="serial"><constraints primaryKey="true" /></column>
             <column name="subject_id" type="integer"><constraints nullable="false" referencedTableName="subject" referencedColumnNames="id" foreignKeyName="subject_translation_subject_id_fkey" /></column>
@@ -155,6 +186,112 @@
             <column name="name" type="varchar(255)" />
         </createTable>
         <addUniqueConstraint tableName="resource_type_translation" columnNames="resource_type_id,language_code" constraintName="resource_type_language_unique" />
+        <sql>
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (1, 'nb', 'Læringssti');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (1, 'nn', 'Læringssti');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (1, 'en', 'Learning path');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (1, 'se', 'Oahppanbálggis');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (2, 'nb', 'Fagstoff');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (2, 'nn', 'Fagstoff');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (2, 'en', 'Subject Material');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (2, 'se', 'Fágaávnnas');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (3, 'nb', 'Fagartikkel');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (3, 'nn', 'Fagartikkel');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (3, 'en', 'Article');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (3, 'se', 'Fágaartihkal');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (4, 'nb', 'Veiledning');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (4, 'nn', 'Rettleiing');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (4, 'en', 'Guidance');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (4, 'se', 'Bagadus');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (5, 'nb', 'Oppgaver og aktiviteter');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (5, 'nn', 'Oppgåver og aktivitetar');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (5, 'en', 'Tasks and Activites');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (5, 'se', 'Bargobihtát ja doaimmat');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (6, 'nb', 'Oppgave');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (6, 'nn', 'Oppgåve');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (6, 'en', 'Task');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (6, 'se', 'Bargobihttá');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (7, 'nb', 'Film og filmklipp');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (7, 'nn', 'Film og filmklipp');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (7, 'en', 'Films and Film clips');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (7, 'se', 'Filmmat ja filbmaoasážat');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (8, 'nb', 'Forelesing og presentasjon');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (8, 'nn', 'Førelesing og presentasjon');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (8, 'en', 'Lectures and Presentations');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (8, 'se', 'Logaldallan ja ovdanbuktin');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (9, 'nb', 'Simulering');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (9, 'nn', 'Simulering');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (9, 'en', 'Simulations');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (9, 'se', 'Simuleren');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (10, 'nb', 'Øvelse');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (10, 'nn', 'Øving');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (10, 'en', 'Exercise');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (10, 'se', 'Hárjehus');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (11, 'nb', 'Vurderingsressurs');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (11, 'nn', 'Vurderingsressurs');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (11, 'en', 'Assessment Resources');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (11, 'se', 'Árvvoštallanresursa');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (12, 'nb', 'Egenvurdering');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (12, 'nn', 'Eigenvurdering');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (12, 'en', 'Self Evaluation');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (12, 'se', 'Iežas árvvoštallan');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (14, 'nb', 'Spill');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (14, 'nn', 'Spel');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (14, 'en', 'Game');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (14, 'se', 'Speallu');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (15, 'nb', 'Arbeidsoppdrag');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (15, 'nn', 'Arbeidsoppdrag');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (15, 'en', 'Work Assignment');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (15, 'se', 'Bargodoaibma');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (16, 'nb', 'Oppslagsverk og ordliste');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (16, 'nn', 'Oppslagsverk og ordliste');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (16, 'en', 'Dictionary');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (16, 'se', 'Diehtogirjjit ja sátnegirji');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (17, 'nb', 'Verktøy og mal');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (17, 'nn', 'Verktøy og mal');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (17, 'en', 'Tools and Templates');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (17, 'se', 'Reaiddut ja málle');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (18, 'nb', 'Kildemateriell');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (18, 'nn', 'Kjeldemateriale');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (18, 'en', 'External resources');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (18, 'se', 'Gáldomateriála');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (19, 'nb', 'Spillefilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (19, 'nn', 'Spelefilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (19, 'en', 'Feature Film');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (19, 'se', 'Guoimmuhanfilbma');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (20, 'nb', 'Kortfilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (20, 'nn', 'Kortfilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (20, 'en', 'Short Film');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (20, 'se', 'Oanehisfilbma');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (24, 'nb', 'Historisk materiale');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (24, 'nn', 'Historiske kjelder');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (24, 'en', 'Historical Sources');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (24, 'se', 'Historjjálaš materiála');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (25, 'nb', 'Litterære tekster');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (25, 'nn', 'Litterære tekstar');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (25, 'en', 'Literary Text');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (25, 'se', 'Girjjálašvuođa teavsttat');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (27, 'nb', 'Lydopptak');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (27, 'nn', 'Lydopptak');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (27, 'en', 'Sound Recordings');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (27, 'se', 'Jietnabádden');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (28, 'nb', 'Forsøk');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (28, 'nn', 'Forsøk');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (28, 'en', 'Experiment');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (28, 'se', 'Geahččaladdan');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (32, 'nb', 'Filmklipp');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (32, 'nn', 'Filmklipp');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (32, 'en', 'Film Clip');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (32, 'se', 'Filbmaoasáš');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (33, 'nb', 'Serier');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (33, 'nn', 'Seriar');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (33, 'en', 'Series');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (33, 'se', 'Ráiddut');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (34, 'nb', 'Dokumentarfilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (34, 'nn', 'Dokumentarfilm');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (34, 'en', 'Documentary');
+            INSERT INTO resource_type_translation (resource_type_id, language_code, name) VALUES (34, 'se', 'Dokumentára filbma');
+        </sql>
     </changeSet>
 
     <changeSet id="20190605 v11 set primary" author="Migrated From Flyway">

--- a/src/main/resources/db-migrate-from-flyway.xml
+++ b/src/main/resources/db-migrate-from-flyway.xml
@@ -227,11 +227,17 @@
     </changeSet>
 
     <changeSet id="20190605 v14 resource_filter" author="Migrated From Flyway">
+        <validCheckSum>8:8443ad1a262444b09395879a5c673232</validCheckSum>
         <createTable tableName="relevance">
             <column name="id" type="serial"><constraints primaryKey="true" /></column>
             <column name="public_id" type="varchar(255)"><constraints nullable="false" unique="true" uniqueConstraintName="relevance_public_id" /></column>
             <column name="name" type="varchar(255)" />
         </createTable>
+        <sql>
+            INSERT INTO relevance (id, public_id, name) VALUES (1, 'urn:relevance:core', 'Kjernestoff');
+            INSERT INTO relevance (id, public_id, name) VALUES (2, 'urn:relevance:supplementary', 'Tilleggstoff');
+            ALTER SEQUENCE relevance_id_seq RESTART WITH 3;
+        </sql>
 
         <createTable tableName="relevance_translation">
             <column name="id" type="serial"><constraints primaryKey="true" /></column>
@@ -240,6 +246,16 @@
             <column name="name" type="varchar(255)" />
         </createTable>
         <addUniqueConstraint tableName="relevance_translation" columnNames="relevance_id,language_code" constraintName="relevance_language_unique" />
+        <sql>
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (1, 'nb', 'Kjernestoff');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (1, 'nn', 'Kjernestoff');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (1, 'en', 'Core content');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (1, 'se', 'Guovddášávnnas');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (2, 'nb', 'Tilleggsstoff');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (2, 'nn', 'Tilleggsstoff');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (2, 'en', 'Supplementary content');
+            INSERT INTO relevance_translation (relevance_id, language_code, name) VALUES (2, 'se', 'Lassiávnnas');
+        </sql>
 
         <createTable tableName="resource_filter">
             <column name="id" type="serial"><constraints primaryKey="true" /></column>

--- a/src/test/java/no/ndla/taxonomy/domain/Builder.java
+++ b/src/test/java/no/ndla/taxonomy/domain/Builder.java
@@ -88,7 +88,10 @@ public class Builder {
     }
 
     public Relevance core() {
-        return relevance("core", f -> f.publicId("urn:relevance:core").name("Core"));
+        return entityManager
+                .createQuery("select r from Relevance r where r.publicId = :publicId", Relevance.class)
+                .setParameter("publicId", URI.create("urn:relevance:core"))
+                .getSingleResult();
     }
 
     private VersionBuilder getVersionBuilder(String key) {
@@ -470,7 +473,7 @@ public class Builder {
         }
 
         public NodeBuilder resource(Node resource, boolean primary) {
-            entityManager.persist(NodeConnection.create(node, resource, relevance(), primary));
+            entityManager.persist(NodeConnection.create(node, resource, core(), primary));
 
             contextUpdaterService.updateContexts(resource);
 

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeConnectionsTest.java
@@ -32,8 +32,6 @@ public class NodeConnectionsTest extends RestTest {
     public void add_core_relevance() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodeResourcesTest.java
@@ -31,8 +31,6 @@ public class NodeResourcesTest extends RestTest {
     public void add_core_relevance() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
@@ -43,8 +43,6 @@ public class NodesTest extends RestTest {
         nodeConnectionRepository.deleteAllAndFlush();
         resourceTypeRepository.deleteAllAndFlush();
         resourceResourceTypeRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
@@ -28,8 +28,6 @@ public class QueryTest extends RestTest {
     public void add_core_relevance() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/RelevanceTranslationsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/RelevanceTranslationsTest.java
@@ -24,9 +24,6 @@ public class RelevanceTranslationsTest extends RestTest {
 
     @Test
     public void can_get_all_relevances() throws Exception {
-        builder.relevance(r -> r.name("Core").translation("Kjernestoff", "nb"));
-        builder.relevance(r -> r.name("Supplementary").translation("Tilleggstoff", "nb"));
-
         MockHttpServletResponse response = testUtils.getResource("/v1/relevances?language=nb");
         RelevanceDTO[] relevances = testUtils.getObject(RelevanceDTO[].class, response);
 

--- a/src/test/java/no/ndla/taxonomy/rest/v1/RelevancesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/RelevancesTest.java
@@ -34,13 +34,12 @@ public class RelevancesTest extends RestTest {
     @Test
     public void can_get_all_relevances() throws Exception {
         builder.relevance(f -> f.publicId("urn:relevance:1").name("Core material"));
-
         builder.relevance(f -> f.publicId("urn:relevance:2").name("Supplementary material"));
 
         MockHttpServletResponse response = testUtils.getResource("/v1/relevances");
         RelevanceDTO[] relevances = testUtils.getObject(RelevanceDTO[].class, response);
 
-        assertEquals(2, relevances.length);
+        assertEquals(4, relevances.length);
         assertAnyTrue(relevances, f -> f.name.equals("Core material"));
         assertAnyTrue(relevances, f -> f.name.equals("Supplementary material"));
     }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/ResourceTypeTranslationsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/ResourceTypeTranslationsTest.java
@@ -9,8 +9,7 @@ package no.ndla.taxonomy.rest.v1;
 
 import static no.ndla.taxonomy.TestUtils.assertAnyTrue;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.net.URI;
 import no.ndla.taxonomy.domain.ResourceType;
@@ -30,7 +29,7 @@ public class ResourceTypeTranslationsTest extends RestTest {
         MockHttpServletResponse response = testUtils.getResource("/v1/resource-types?language=nb");
         ResourceTypeDTO[] resourceTypes = testUtils.getObject(ResourceTypeDTO[].class, response);
 
-        assertEquals(2, resourceTypes.length);
+        assertTrue(resourceTypes.length >= 2);
         assertAnyTrue(resourceTypes, s -> s.name.equals("Artikkel"));
         assertAnyTrue(resourceTypes, s -> s.name.equals("Forelesning"));
     }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/ResourceTypesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/ResourceTypesTest.java
@@ -26,14 +26,14 @@ public class ResourceTypesTest extends RestTest {
         builder.resourceType(rt -> rt.name("audio"));
 
         MockHttpServletResponse response = testUtils.getResource("/v1/resource-types");
-        ResourceTypeDTO[] resourcetypes = testUtils.getObject(ResourceTypeDTO[].class, response);
+        ResourceTypeDTO[] resourceTypes = testUtils.getObject(ResourceTypeDTO[].class, response);
 
-        assertEquals(2, resourcetypes.length);
+        assertTrue(resourceTypes.length >= 2);
         assertAnyTrue(
-                resourcetypes,
+                resourceTypes,
                 s -> "video".equals(s.name) && s.subtypes.get(0).name.equals("lecture"));
-        assertAnyTrue(resourcetypes, s -> "audio".equals(s.name));
-        assertAllTrue(resourcetypes, s -> isValidId(s.id));
+        assertAnyTrue(resourceTypes, s -> "audio".equals(s.name));
+        assertAllTrue(resourceTypes, s -> isValidId(s.id));
     }
 
     @Test
@@ -54,7 +54,7 @@ public class ResourceTypesTest extends RestTest {
         MockHttpServletResponse response = testUtils.getResource("/v1/resource-types?language=nb");
         ResourceTypeDTO[] resourcetypes = testUtils.getObject(ResourceTypeDTO[].class, response);
 
-        assertEquals(2, resourcetypes.length);
+        assertTrue(resourcetypes.length >= 2);
         assertAnyTrue(resourcetypes, s -> "film".equals(s.name));
         assertAnyTrue(resourcetypes, s -> "lydklipp".equals(s.name));
     }

--- a/src/test/java/no/ndla/taxonomy/rest/v1/ResourcesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/ResourcesTest.java
@@ -37,8 +37,6 @@ public class ResourcesTest extends RestTest {
     void clearAllRepos() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/SubjectTopicsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/SubjectTopicsTest.java
@@ -30,8 +30,6 @@ public class SubjectTopicsTest extends RestTest {
     void clearAllRepos() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/SubjectsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/SubjectsTest.java
@@ -33,8 +33,6 @@ public class SubjectsTest extends RestTest {
     void clearAllRepos() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/TopicResourcesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/TopicResourcesTest.java
@@ -33,8 +33,6 @@ public class TopicResourcesTest extends RestTest {
     public void add_core_relevance() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/TopicSubtopicsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/TopicSubtopicsTest.java
@@ -28,8 +28,6 @@ public class TopicSubtopicsTest extends RestTest {
     public void add_core_relevance() {
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
-
-        builder.core();
     }
 
     @Test

--- a/src/test/java/no/ndla/taxonomy/rest/v1/TopicsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/TopicsTest.java
@@ -36,7 +36,6 @@ public class TopicsTest extends RestTest {
     @BeforeEach
     void clearAllRepos() {
         nodeRepository.deleteAllAndFlush();
-        builder.core();
     }
 
     @Test


### PR DESCRIPTION
Justerer gamle migreringer til å ha relevances og resourcetypes i henhold til prod. Gjør at det skal være mogeleg å starte opp applikasjonen mot tom database.