### PR TITLE
Add functionality to `/search` to filter by customfields

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -22,6 +22,7 @@ import no.ndla.taxonomy.domain.exceptions.NotFoundException;
 import no.ndla.taxonomy.repositories.NodeConnectionRepository;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.rest.v1.commands.NodePostPut;
+import no.ndla.taxonomy.rest.v1.commands.NodeSearchBody;
 import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.*;
 import org.springframework.data.domain.PageRequest;
@@ -142,10 +143,37 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")
                     @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
-                    boolean filterProgrammes) {
-
+                    boolean filterProgrammes
+            ) {
         return nodeService.searchByNodeType(
-                query, ids, contentUris, language, includeContexts, filterProgrammes, pageSize, page, nodeType);
+                query,
+                ids,
+                contentUris,
+                language,
+                includeContexts,
+                filterProgrammes,
+                pageSize,
+                page,
+                nodeType,
+                Optional.empty());
+    }
+
+    @PostMapping("/search")
+    @Operation(summary = "Search all nodes")
+    @Transactional(readOnly = true)
+    public SearchResultDTO<NodeDTO> searchNodes(@RequestBody NodeSearchBody searchBodyParams) {
+        return nodeService.searchByNodeType(
+                searchBodyParams.query,
+                searchBodyParams.ids,
+                searchBodyParams.contentUris,
+                searchBodyParams.language,
+                searchBodyParams.includeContexts,
+                searchBodyParams.filterProgrammes,
+                searchBodyParams.pageSize,
+                searchBodyParams.page,
+                searchBodyParams.nodeType,
+                searchBodyParams.customFields
+        );
     }
 
     @GetMapping("/page")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -117,7 +117,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(List.of(NodeType.RESOURCE)));
+                Optional.of(List.of(NodeType.RESOURCE)),
+                Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -115,7 +115,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(List.of(NodeType.SUBJECT)));
+                Optional.of(List.of(NodeType.SUBJECT)),
+                Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -102,7 +102,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 false,
                 pageSize,
                 page,
-                Optional.of(List.of(NodeType.TOPIC)));
+                Optional.of(List.of(NodeType.TOPIC)),
+                Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodeSearchBody.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodeSearchBody.java
@@ -1,0 +1,68 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.rest.v1.commands;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import no.ndla.taxonomy.config.Constants;
+import no.ndla.taxonomy.domain.NodeType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class NodeSearchBody {
+    @JsonProperty
+    @Schema(
+            description =
+                    "If specified, the search result will be filtered by whether they include the key,value combination provided. If more than one provided only one will be required (OR)")
+    public Optional<Map<String, String>> customFields = Optional.empty();
+
+
+    @Schema(description = "ISO-639-1 language code", example = "nb")
+    @JsonProperty
+    public Optional<String> language = Optional.of(Constants.DefaultLanguage);
+
+
+    @Schema(description = "How many results to return per page")
+    @JsonProperty
+    public int pageSize = 10;
+
+    @Schema(description = "Which page to fetch")
+    @JsonProperty
+    public int page = 1;
+
+    @Schema(description = "Query to search names")
+    @JsonProperty
+    public Optional<String> query = Optional.empty();
+
+    @Schema(description = "Ids to fetch for query")
+    @JsonProperty
+    public Optional<List<String>> ids = Optional.empty();
+
+    @Schema(description = "ContentURIs to fetch for query")
+    @JsonProperty
+    public Optional<List<String>> contentUris = Optional.empty();
+
+    @Schema(description = "Filter by nodeType")
+    @JsonProperty
+    public Optional<List<NodeType>> nodeType = Optional.empty();
+
+    @Schema(description = "Include all contexts")
+    @JsonProperty
+    public Optional<Boolean> includeContexts = Optional.empty();
+
+    @Schema(description = "Filter out programme contexts")
+    @JsonProperty
+    public boolean filterProgrammes;
+
+    public Optional<Map<String, String>> getCustomFields() {
+        return customFields;
+    }
+
+}

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -322,10 +322,20 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
             boolean filterProgrammes,
             int pageSize,
             int page,
-            Optional<List<NodeType>> nodeType) {
+            Optional<List<NodeType>> nodeType,
+            Optional<Map<String, String>> customfieldsFilter) {
         Optional<ExtraSpecification<Node>> nodeSpecLambda = nodeType.map(nt -> (s -> s.and(nodeHasOneOfNodeType(nt))));
         return SearchService.super.search(
-                query, ids, contentUris, language, includeContexts, filterProgrammes, pageSize, page, nodeSpecLambda);
+                query,
+                ids,
+                contentUris,
+                language,
+                includeContexts,
+                filterProgrammes,
+                pageSize,
+                page,
+                nodeSpecLambda,
+                customfieldsFilter);
     }
 
     @Transactional

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -12,6 +12,7 @@ import static org.springframework.data.jpa.domain.Specification.where;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import no.ndla.taxonomy.domain.DomainEntity;
@@ -46,6 +47,16 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
         return (root, query, criteriaBuilder) -> root.get("contentUri").in(contentUris);
     }
 
+    private Specification<DOMAIN> withKeyAndValue(String key, String value) {
+        return (root, query, criteriaBuilder) -> criteriaBuilder.equal(
+                criteriaBuilder.function(
+                        "jsonb_extract_path_text",
+                        String.class,
+                        root.get("customfields"),
+                        criteriaBuilder.literal(key)),
+                value);
+    }
+
     default SearchResultDTO<DTO> search(
             Optional<String> query,
             Optional<List<String>> ids,
@@ -54,7 +65,17 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
             Optional<Boolean> includeContext,
             int pageSize,
             int page) {
-        return search(query, ids, contentUris, language, includeContext, false, pageSize, page, Optional.empty());
+        return search(
+                query,
+                ids,
+                contentUris,
+                language,
+                includeContext,
+                false,
+                pageSize,
+                page,
+                Optional.empty(),
+                Optional.empty());
     }
 
     default SearchResultDTO<DTO> search(
@@ -66,7 +87,8 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
             boolean filterProgrammes,
             int pageSize,
             int page,
-            Optional<ExtraSpecification<DOMAIN>> applySpecLambda) {
+            Optional<ExtraSpecification<DOMAIN>> applySpecLambda,
+            Optional<Map<String, String>> customFieldFilters) {
         if (page < 1) throw new IllegalArgumentException("page parameter must be bigger than 0");
 
         var pageRequest = PageRequest.of(page - 1, pageSize);
@@ -76,37 +98,14 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
             spec = spec.and(withNameLike(query.get()));
         }
 
-        if (ids.isPresent()) {
-            List<URI> urisToPass = ids.get().stream()
-                    .flatMap(id -> {
-                        try {
-                            return Optional.of(new URI(id)).stream();
-                        } catch (URISyntaxException ignored) {
-                            /* ignore invalid urls sent by user */ }
-                        return Optional.<URI>empty().stream();
-                    })
-                    .collect(Collectors.toList());
-
-            if (!urisToPass.isEmpty()) spec = spec.and(withPublicIdsIn(urisToPass));
-        }
-
-        if (contentUris.isPresent()) {
-            List<URI> urisToPass = contentUris.get().stream()
-                    .flatMap(id -> {
-                        try {
-                            return Optional.of(new URI(id)).stream();
-                        } catch (URISyntaxException ignored) {
-                            /* ignore invalid urls sent by user */ }
-                        return Optional.<URI>empty().stream();
-                    })
-                    .collect(Collectors.toList());
-
-            if (!urisToPass.isEmpty()) spec = spec.and(withContentUriIn(urisToPass));
-        }
+        spec = applyIdFilters(ids, spec);
+        spec = applyContentUriFilters(contentUris, spec);
 
         if (applySpecLambda.isPresent()) {
             spec = applySpecLambda.get().applySpecification(spec);
         }
+
+        spec = applyCustomFieldsFilters(spec, customFieldFilters);
 
         var fetched = getRepository().findAll(spec, pageRequest);
 
@@ -116,5 +115,60 @@ public interface SearchService<DTO, DOMAIN extends DomainEntity, REPO extends Ta
                 .collect(Collectors.toList());
 
         return new SearchResultDTO<>(fetched.getTotalElements(), page, pageSize, dtos);
+    }
+
+    private Specification<DOMAIN> applyContentUriFilters(
+            Optional<List<String>> contentUris, Specification<DOMAIN> spec) {
+        if (contentUris.isPresent()) {
+            List<URI> urisToPass = contentUris.get().stream()
+                    .flatMap(id -> {
+                        try {
+                            return Optional.of(new URI(id)).stream();
+                        } catch (URISyntaxException ignored) {
+                            /* ignore invalid urls sent by user */
+                        }
+                        return Optional.<URI>empty().stream();
+                    })
+                    .collect(Collectors.toList());
+
+            if (!urisToPass.isEmpty()) spec = spec.and(withContentUriIn(urisToPass));
+        }
+        return spec;
+    }
+
+    private Specification<DOMAIN> applyIdFilters(Optional<List<String>> ids, Specification<DOMAIN> spec) {
+        if (ids.isPresent()) {
+            List<URI> urisToPass = ids.get().stream()
+                    .flatMap(id -> {
+                        try {
+                            return Optional.of(new URI(id)).stream();
+                        } catch (URISyntaxException ignored) {
+                            /* ignore invalid urls sent by user */
+                        }
+                        return Optional.<URI>empty().stream();
+                    })
+                    .collect(Collectors.toList());
+
+            if (!urisToPass.isEmpty()) spec = spec.and(withPublicIdsIn(urisToPass));
+        }
+        return spec;
+    }
+
+    private Specification<DOMAIN> applyCustomFieldsFilters(
+            Specification<DOMAIN> spec, Optional<Map<String, String>> metadataFilters) {
+        if (metadataFilters.isPresent()) {
+            Specification<DOMAIN> filterSpec = null;
+            for (var entry : metadataFilters.get().entrySet()) {
+                if (filterSpec != null) {
+                    filterSpec = filterSpec.or(withKeyAndValue(entry.getKey(), entry.getValue()));
+                } else {
+                    filterSpec = withKeyAndValue(entry.getKey(), entry.getValue());
+                }
+            }
+            if (filterSpec != null) {
+                return spec.and(filterSpec);
+            }
+        }
+        return spec;
     }
 }

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -119,7 +119,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
-                Optional.of(List.of(NodeType.SUBJECT)));
+                Optional.of(List.of(NodeType.SUBJECT)),
+                Optional.empty());
 
         var topics = nodeService.searchByNodeType(
                 Optional.empty(),
@@ -130,7 +131,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
-                Optional.of(List.of(NodeType.TOPIC)));
+                Optional.of(List.of(NodeType.TOPIC)),
+                Optional.empty());
         var all = nodeService.searchByNodeType(
                 Optional.empty(),
                 Optional.empty(),
@@ -140,6 +142,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
+                Optional.empty(),
                 Optional.empty());
 
         assertEquals(subjects.getResults().get(0).getId(), subject.getPublicId());


### PR DESCRIPTION
Legger til POST `/v1/nodes/search` endepunktet med optional body for å kunne filtrere på customfields.
Feltene blir OR'et
Kan testes med feks

```http
POST /v1/nodes/search
{
  "customFields": {
    "subjectLMA": "123",
    "noe-annet": "apekatt"
  }
}

```