### PR TITLE
Handle contextid separately when fetching nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,8 @@
         <java.version>17</java.version>
         <javamelody.version>2.1.0</javamelody.version>
         <spotless.version>2.40.0</spotless.version>
+        <postgresql.version>42.7.2</postgresql.version>
+        <testcontainers.version>1.19.7</testcontainers.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -97,7 +97,8 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<String> value,
             @Parameter(description = "Filter by visible") @RequestParam(value = "isVisible", required = false)
                     Optional<Boolean> isVisible,
-            @Parameter(description = "Filter by context id. Handled separately from other parameters") @RequestParam(value = "contextId", required = false)
+            @Parameter(description = "Filter by context id. Beware: handled separately from other parameters!")
+                    @RequestParam(value = "contextId", required = false)
                     Optional<String> contextId,
             @Parameter(description = "Include all contexts") @RequestParam(value = "includeContexts", required = false)
                     Optional<Boolean> includeContexts,

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -97,7 +97,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<String> value,
             @Parameter(description = "Filter by visible") @RequestParam(value = "isVisible", required = false)
                     Optional<Boolean> isVisible,
-            @Parameter(description = "Filter by context id") @RequestParam(value = "contextId", required = false)
+            @Parameter(description = "Filter by context id. Handled separately from other parameters") @RequestParam(value = "contextId", required = false)
                     Optional<String> contextId,
             @Parameter(description = "Include all contexts") @RequestParam(value = "includeContexts", required = false)
                     Optional<Boolean> includeContexts,

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1473,4 +1473,10 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20240307 Add index on node contexts" author="Gunnar Velle">
+        <sql>
+            CREATE INDEX IF NOT EXISTS node_contexts_index ON node USING GIN (contexts);
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/service/AbstractIntegrationTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/AbstractIntegrationTest.java
@@ -22,7 +22,7 @@ public class AbstractIntegrationTest {
     static final PostgreSQLContainer<?> postgresDB;
 
     static {
-        postgresDB = new PostgreSQLContainer<>("postgres:13.7");
+        postgresDB = new PostgreSQLContainer<>("postgres:13.12");
         postgresDB.start();
     }
 


### PR DESCRIPTION
Skiller ut spørring på contextid som egen funksjon.

jsonb_contains og @> skal i utgangspunktet være samme spørringa, men av en eller anna grunn så bruker jsonb_contains ca ett sekund mens @> bruker 50ms. Men for å kunne bruke @> i spørringa må den være native for at operatoren ikkje skal tolkes av hibernate..