### PR TITLE
Use 10 characters for medium hash. Use parent context for new id.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -71,7 +71,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                                 .flatMap(relevance -> Optional.of(
                                                         relevance.getPublicId().toString()))
                                                 .orElse("urn:relevance:core"),
-                                        HashUtil.semiHash(parentContext.rootId() + parentConnection.getPublicId()),
+                                        HashUtil.mediumHash(parentContext.contextId() + parentConnection.getPublicId()),
                                         parentConnection.getRank(),
                                         parentConnection.getPublicId().toString());
                             })

--- a/src/main/java/no/ndla/taxonomy/util/HashUtil.java
+++ b/src/main/java/no/ndla/taxonomy/util/HashUtil.java
@@ -24,7 +24,7 @@ public class HashUtil {
     }
 
     public static String mediumHash(Object original) {
-        return generateHash(original, 8);
+        return generateHash(original, 10);
     }
 
     public static String semiHash(Object original) {

--- a/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/QueryTest.java
@@ -402,14 +402,10 @@ public class QueryTest extends RestTest {
                                 .contentUri("urn:article:1")
                                 .publicId("urn:resource:1"))));
         Node resource = nodeRepository.getByPublicId(URI.create("urn:resource:1"));
-        String hash = HashUtil.semiHash(root.getPublicId().toString()
-                + resource.getParentConnections().stream()
-                        .findFirst()
-                        .get()
-                        .getPublicId()
-                        .toString());
-
-        var response = testUtils.getResource("/v1/queries/path?path=" + String.format("/one-fine-resource__%s", hash));
+        var response = testUtils.getResource("/v1/queries/path?path="
+                + String.format(
+                "/one-fine-resource__%s",
+                resource.getContexts().stream().findFirst().get().contextId()));
         var result = testUtils.getObject(TaxonomyContextDTO[].class, response);
 
         assertEquals(1, result.length);

--- a/src/test/java/no/ndla/taxonomy/util/HashUtilTest.java
+++ b/src/test/java/no/ndla/taxonomy/util/HashUtilTest.java
@@ -22,7 +22,7 @@ public class HashUtilTest {
         String fullHash = HashUtil.fullHash("original");
 
         assertEquals(4, shortHash.length());
-        assertEquals(8, mediumHash.length());
+        assertEquals(10, mediumHash.length());
         assertEquals(12, semiHash.length());
         assertEquals(16, longHash.length());
         assertTrue(fullHash.length() > 16);


### PR DESCRIPTION
Har testa med 350000 kontekster og 10 tegn gjør at eg ikkje får kollisjoner. Det er nok ikkje garantert at det ikkje vil oppstå kollisjoner, men mindre sannsynlig.