### PR TITLE
Simplify fetching child resources

### DIFF
--- a/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
@@ -31,33 +31,18 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
     @Query(
             """
             SELECT DISTINCT nc FROM NodeConnection nc
-            LEFT JOIN FETCH nc.child child
-            LEFT JOIN FETCH nc.parent n
-            LEFT JOIN FETCH child.resourceResourceTypes rrt
+            LEFT JOIN FETCH nc.child c
+            LEFT JOIN FETCH nc.parent p
+            LEFT JOIN FETCH c.resourceResourceTypes rrt
             LEFT JOIN FETCH nc.relevance rel
             LEFT JOIN FETCH rrt.resourceType rt
-            WHERE n.publicId IN :nodeIds
-            AND ((:#{#resourceTypePublicIds == null} = true) OR rt.publicId IN :resourceTypePublicIds)
-            AND (:relevancePublicId IS NULL OR rel.publicId = :relevancePublicId)
-            AND child.nodeType = 'RESOURCE'
+            WHERE p.publicId IN :nodeIds
+            AND ((:#{#resourceTypeIds == null} = true) OR rt.publicId IN :resourceTypeIds)
+            AND (:relevanceId IS NULL OR rel.publicId = :relevanceId)
+            AND c.nodeType = 'RESOURCE'
             """)
-    List<NodeConnection> getResourceBy(Set<URI> nodeIds, Set<URI> resourceTypePublicIds, URI relevancePublicId);
-
-    @Query(
-            """
-            SELECT DISTINCT nc FROM NodeConnection nc
-            JOIN FETCH nc.child r
-            LEFT JOIN FETCH nc.parent n
-            LEFT JOIN FETCH r.resourceResourceTypes rrt
-            LEFT JOIN FETCH nc.relevance rel
-            LEFT JOIN FETCH rrt.resourceType rt
-            WHERE n.publicId IN :nodeIds
-            AND r.nodeType = 'RESOURCE'
-            """)
-    List<NodeConnection> getByResourceIds(Collection<URI> nodeIds);
-
-    @Query("SELECT nc FROM NodeConnection nc JOIN FETCH nc.parent JOIN FETCH nc.child")
-    List<NodeConnection> findAllIncludingParentAndChild();
+    List<NodeConnection> getResourceBy(
+            Set<URI> nodeIds, Optional<List<URI>> resourceTypeIds, Optional<URI> relevanceId);
 
     @Query(
             "SELECT nc FROM NodeConnection nc JOIN FETCH nc.parent JOIN FETCH nc.child c WHERE c.nodeType = :childNodeType")

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeConnectionRepository.java
@@ -31,11 +31,11 @@ public interface NodeConnectionRepository extends TaxonomyRepository<NodeConnect
     @Query(
             """
             SELECT DISTINCT nc FROM NodeConnection nc
-            LEFT JOIN FETCH nc.child c
-            LEFT JOIN FETCH nc.parent p
-            LEFT JOIN FETCH c.resourceResourceTypes rrt
-            LEFT JOIN FETCH nc.relevance rel
-            LEFT JOIN FETCH rrt.resourceType rt
+            LEFT JOIN nc.child c
+            LEFT JOIN nc.parent p
+            LEFT JOIN c.resourceResourceTypes rrt
+            LEFT JOIN nc.relevance rel
+            LEFT JOIN rrt.resourceType rt
             WHERE p.publicId IN :nodeIds
             AND ((:#{#resourceTypeIds == null} = true) OR rt.publicId IN :resourceTypeIds)
             AND (:relevanceId IS NULL OR rel.publicId = :relevanceId)

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -377,20 +377,13 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                                     "Select by resource type id(s). If not specified, resources of all types will be returned. "
                                             + "Multiple ids may be separated with comma or the parameter may be repeated for each id.")
                     @RequestParam(value = "type", required = false)
-                    URI[] resourceTypeIds,
+                    Optional<List<URI>> resourceTypeIds,
             @Parameter(description = "Select by relevance. If not specified, all resources will be returned.")
                     @RequestParam(value = "relevance", required = false)
-                    URI relevance) {
-        final Set<URI> resourceTypeIdSet;
-
-        if (resourceTypeIds == null) {
-            resourceTypeIdSet = Set.of();
-        } else {
-            resourceTypeIdSet = new HashSet<>(Arrays.asList(resourceTypeIds));
-        }
+                    Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                nodeId, resourceTypeIdSet, relevance, language, recursive, includeContexts, filterProgrammes);
+                nodeId, resourceTypeIds, relevance, language, recursive, includeContexts, filterProgrammes);
     }
 
     @GetMapping("{id}/full")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -326,17 +326,13 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                             description =
                                     "Filter by resource type id(s). If not specified, resources of all types will be returned."
                                             + "Multiple ids may be separated with comma or the parameter may be repeated for each id.")
-                    @RequestParam(value = "type", required = false, defaultValue = "")
-                    URI[] resourceTypeIds,
+                    @RequestParam(value = "type", required = false)
+                    Optional<List<URI>> resourceTypeIds,
             @Parameter(description = "Select by relevance. If not specified, all resources will be returned.")
-                    @RequestParam(value = "relevance", required = false, defaultValue = "")
-                    URI relevance) {
-        final Set<URI> resourceTypeIdSet = resourceTypeIds != null ? Set.of(resourceTypeIds) : Set.of();
-
-        // If null is sent to query it will be ignored, otherwise it will filter by relevance
-        final var relevanceArgument = relevance == null || relevance.toString().equals("") ? null : relevance;
+                    @RequestParam(value = "relevance", required = false)
+                    Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                subjectId, resourceTypeIdSet, relevanceArgument, language, true, Optional.of(false), false);
+                subjectId, resourceTypeIds, relevance, language, true, Optional.of(false), false);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -235,20 +235,13 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                                     "Select by resource type id(s). If not specified, resources of all types will be returned."
                                             + "Multiple ids may be separated with comma or the parameter may be repeated for each id.")
                     @RequestParam(value = "type", required = false)
-                    URI[] resourceTypeIds,
+                    Optional<List<URI>> resourceTypeIds,
             @Parameter(description = "Select by relevance. If not specified, all resources will be returned.")
                     @RequestParam(value = "relevance", required = false)
-                    URI relevance) {
-        final Set<URI> resourceTypeIdSet;
-
-        if (resourceTypeIds == null) {
-            resourceTypeIdSet = Set.of();
-        } else {
-            resourceTypeIdSet = new HashSet<>(Arrays.asList(resourceTypeIds));
-        }
+                    Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                topicId, resourceTypeIdSet, relevance, language, recursive, Optional.of(false), false);
+                topicId, resourceTypeIds, relevance, language, recursive, Optional.of(false), false);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -7,8 +7,6 @@
 
 package no.ndla.taxonomy.service;
 
-import static java.util.stream.Collectors.toList;
-
 import java.net.URI;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -295,7 +293,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                             includeContexts,
                             filterProgrammes);
                 })
-                .collect(toList());
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
Slår sammen to nesten like spørringer i connection repo og bruker optionals i stedet for null-håndtering.
Fjerner FETCH fra spørringene slik at vi ikkje lenger ber databasen om å hente alle data på en gong. Det burde gjøre den eine spørringa som bruker mest ressurser litt kjappere
![image](https://github.com/NDLANO/taxonomy-api/assets/8956884/ae12c905-6d3f-4456-9157-ad2167934006)
