### PR TITLE
Generate url based on root and node.

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/TaxonomyContext.java
+++ b/src/main/java/no/ndla/taxonomy/domain/TaxonomyContext.java
@@ -28,7 +28,6 @@ import java.util.Optional;
  * @param relevanceId      ID of relevance. From nodeConnection.
  * @param contextId        Hash of root publicId + nodeConnection publicId. Unique for this context.
  * @param rank             The rank of the context. From nodeConnection.
- * @param url              A pretty url based on node name and contextId for this context.
  * @param connectionId     The id of the connection. From nodeConnection.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -46,5 +45,4 @@ public record TaxonomyContext(
         String relevanceId,
         String contextId,
         int rank,
-        Optional<String> url,
         String connectionId) {}

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -25,6 +25,7 @@ import no.ndla.taxonomy.rest.v1.commands.NodePostPut;
 import no.ndla.taxonomy.rest.v1.commands.NodeSearchBody;
 import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +41,9 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
     private final NodeService nodeService;
     private final RecursiveNodeTreeService recursiveNodeTreeService;
     private final TreeSorter treeSorter;
+
+    @Value(value = "${new.url.separator:false}")
+    private boolean newUrlSeparator;
 
     public Nodes(
             NodeRepository nodeRepository,
@@ -207,7 +211,8 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                         language.orElse("nb"),
                         Optional.empty(),
                         includeContexts,
-                        filterProgrammes))
+                        filterProgrammes,
+                        newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }
@@ -325,7 +330,8 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                         nodeConnection,
                         language.orElse(Constants.DefaultLanguage),
                         includeContexts,
-                        filterProgrammes))
+                        filterProgrammes,
+                        newUrlSeparator))
                 .forEach(returnList::add);
 
         var filtered = returnList.stream()
@@ -401,7 +407,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "Include all contexts") @RequestParam(value = "includeContexts", required = false)
                     Optional<Boolean> includeContexts) {
         var node = nodeService.getNode(id);
-        return new NodeWithParents(node, language.orElse(Constants.DefaultLanguage), includeContexts);
+        return new NodeWithParents(node, language.orElse(Constants.DefaultLanguage), includeContexts, newUrlSeparator);
     }
 
     @PutMapping("/{id}/makeResourcesPrimary")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -28,6 +28,7 @@ import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.NodeWithParents;
 import no.ndla.taxonomy.service.dtos.ResourceTypeWithConnectionDTO;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -41,6 +42,9 @@ public class Resources extends CrudControllerWithMetadata<Node> {
     private final ResourceResourceTypeRepository resourceResourceTypeRepository;
     private final NodeService nodeService;
     private final NodeRepository nodeRepository;
+
+    @Value(value = "${new.url.separator:false}")
+    private boolean newUrlSeparator;
 
     public Resources(
             NodeRepository nodeRepository,
@@ -148,7 +152,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                         language.orElse("nb"),
                         Optional.empty(),
                         Optional.of(false),
-                        false))
+                        false,
+                        newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }
@@ -243,7 +248,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
         var node = nodeService.getNode(id);
-        return new NodeWithParents(node, language.orElse(Constants.DefaultLanguage), Optional.of(false));
+        return new NodeWithParents(
+                node, language.orElse(Constants.DefaultLanguage), Optional.of(false), newUrlSeparator);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -27,6 +27,7 @@ import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.NodeChildDTO;
 import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.SearchResultDTO;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,6 +43,9 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
     private final NodeService nodeService;
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;
+
+    @Value(value = "${new.url.separator:false}")
+    private boolean newUrlSeparator;
 
     public Subjects(
             TreeSorter treeSorter,
@@ -146,7 +150,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         language.orElse("nb"),
                         Optional.empty(),
                         Optional.of(false),
-                        false))
+                        false,
+                        newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }
@@ -253,7 +258,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         nodeConnection,
                         language.orElse(Constants.DefaultLanguage),
                         Optional.of(false),
-                        false))
+                        false,
+                        newUrlSeparator))
                 .forEach(returnList::add);
 
         var filtered = returnList.stream()

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -23,6 +23,7 @@ import no.ndla.taxonomy.service.ContextUpdaterService;
 import no.ndla.taxonomy.service.MetadataFilters;
 import no.ndla.taxonomy.service.NodeService;
 import no.ndla.taxonomy.service.dtos.*;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,6 +36,9 @@ import org.springframework.web.bind.annotation.*;
 public class Topics extends CrudControllerWithMetadata<Node> {
     private final NodeRepository nodeRepository;
     private final NodeService nodeService;
+
+    @Value(value = "${new.url.separator:false}")
+    private boolean newUrlSeparator;
 
     public Topics(
             NodeRepository nodeRepository, NodeService nodeService, ContextUpdaterService cachedUrlUpdaterService) {
@@ -132,7 +136,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                         language.orElse("nb"),
                         Optional.empty(),
                         Optional.of(false),
-                        false))
+                        false,
+                        newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -13,17 +13,12 @@ import no.ndla.taxonomy.domain.LanguageField;
 import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.TaxonomyContext;
 import no.ndla.taxonomy.util.HashUtil;
-import no.ndla.taxonomy.util.PrettyUrlUtil;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class ContextUpdaterServiceImpl implements ContextUpdaterService {
-
-    @Value(value = "${new.url.separator:false}")
-    private boolean newUrlSeparator;
 
     public ContextUpdaterServiceImpl() {}
 
@@ -50,8 +45,6 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                     "urn:relevance:core",
                     contextId,
                     0,
-                    PrettyUrlUtil.createPrettyUrl(
-                            Optional.empty(), node.getName(), contextId, node.getNodeType(), newUrlSeparator),
                     ""));
         }
 
@@ -87,14 +80,6 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                                 .orElse("urn:relevance:core"),
                                         contextId,
                                         parentConnection.getRank(),
-                                        PrettyUrlUtil.createPrettyUrl(
-                                                Optional.of(parentContext
-                                                        .rootName()
-                                                        .fromLanguage(Constants.DefaultLanguage)),
-                                                node.getName(),
-                                                contextId,
-                                                node.getNodeType(),
-                                                newUrlSeparator),
                                         parentConnection.getPublicId().toString());
                             })
                             .forEach(returnedContexts::add);

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -46,7 +46,8 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
             NodeConnection nodeConnection,
             String language,
             Optional<Boolean> includeContexts,
-            boolean filterProgrammes) {
+            boolean filterProgrammes,
+            boolean newUrlSeparator) {
         super(
                 root,
                 nodeConnection.getParent(),
@@ -54,7 +55,8 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 language,
                 Optional.empty(),
                 includeContexts,
-                filterProgrammes);
+                filterProgrammes,
+                newUrlSeparator);
 
         // This must be enabled when ed is updated to update metadata for connections.
         // this.metadata = new MetadataDto(nodeConnection.getMetadata());
@@ -73,7 +75,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
     /*
      * Special constructor used to get parents for resource/full
      */
-    public NodeChildDTO(Node parent, NodeConnection nodeConnection, String language) {
+    public NodeChildDTO(Node parent, NodeConnection nodeConnection, String language, boolean newUrlSeparator) {
         super(
                 Optional.empty(),
                 nodeConnection.getParent(),
@@ -81,7 +83,8 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 language,
                 Optional.empty(),
                 Optional.of(false),
-                false);
+                false,
+                newUrlSeparator);
 
         this.rank = nodeConnection.getRank();
         this.connectionId = nodeConnection.getPublicId();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -18,6 +18,7 @@ import no.ndla.taxonomy.domain.*;
 import no.ndla.taxonomy.rest.v1.dtos.searchapi.LanguageFieldDTO;
 import no.ndla.taxonomy.rest.v1.dtos.searchapi.SearchableTaxonomyResourceType;
 import no.ndla.taxonomy.rest.v1.dtos.searchapi.TaxonomyContextDTO;
+import no.ndla.taxonomy.util.PrettyUrlUtil;
 
 @Schema(name = "Node")
 public class NodeDTO {
@@ -89,7 +90,8 @@ public class NodeDTO {
             String languageCode,
             Optional<String> contextId,
             Optional<Boolean> includeContexts,
-            boolean filterProgrammes) {
+            boolean filterProgrammes,
+            boolean newUrlSeparator) {
         this.id = entity.getPublicId();
         this.contentUri = Optional.ofNullable(entity.getContentUri());
 
@@ -137,7 +139,13 @@ public class NodeDTO {
                     : breadcrumbList.get(Constants.DefaultLanguage);
             this.relevanceId = Optional.of(URI.create(ctx.relevanceId()));
             this.contextId = Optional.of(ctx.contextId());
-            this.url = ctx.url();
+            this.url = PrettyUrlUtil.createPrettyUrl(
+                    Optional.of(ctx.rootName()),
+                    LanguageField.fromNode(entity),
+                    this.language,
+                    ctx.contextId(),
+                    entity.getNodeType(),
+                    newUrlSeparator);
         });
 
         includeContexts.filter(Boolean::booleanValue).ifPresent(includeCtx -> {
@@ -173,7 +181,13 @@ public class NodeDTO {
                             ctx.contextId(),
                             ctx.rank(),
                             ctx.connectionId(),
-                            ctx.url()))
+                            PrettyUrlUtil.createPrettyUrl(
+                                    Optional.of(ctx.rootName()),
+                                    LanguageField.fromNode(entity),
+                                    this.language,
+                                    ctx.contextId(),
+                                    entity.getNodeType(),
+                                    newUrlSeparator)))
                     .toList();
         });
     }

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -28,13 +28,13 @@ public class NodeWithParents extends NodeDTO {
 
     public NodeWithParents() {}
 
-    public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts, false);
+    public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts, boolean newUrlSeparator) {
+        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts, false, false);
 
         node.getParentConnections().stream()
                 .map(nodeResource -> {
                     Node parent = nodeResource.getParent().orElseThrow(() -> new NotFoundException("Parent not found"));
-                    return new NodeChildDTO(parent, nodeResource, languageCode);
+                    return new NodeChildDTO(parent, nodeResource, languageCode, newUrlSeparator);
                 })
                 .forEach(parents::add);
     }

--- a/src/main/java/no/ndla/taxonomy/util/PrettyUrlUtil.java
+++ b/src/main/java/no/ndla/taxonomy/util/PrettyUrlUtil.java
@@ -8,10 +8,26 @@
 package no.ndla.taxonomy.util;
 
 import java.util.Optional;
+import no.ndla.taxonomy.domain.LanguageField;
 import no.ndla.taxonomy.domain.NodeType;
 import org.jsoup.Jsoup;
 
 public class PrettyUrlUtil {
+
+    public static Optional<String> createPrettyUrl(
+            Optional<LanguageField<String>> rootName,
+            LanguageField<String> name,
+            String language,
+            String hash,
+            NodeType nodeType,
+            boolean newUrlSeparator) {
+        return createPrettyUrl(
+                rootName.map(lf -> lf.fromLanguage(language)),
+                name.fromLanguage(language),
+                hash,
+                nodeType,
+                newUrlSeparator);
+    }
 
     public static Optional<String> createPrettyUrl(
             Optional<String> rootName, String name, String hash, NodeType nodeType, boolean newUrlSeparator) {

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1508,5 +1508,16 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20240606 Remove default url from context again" author="Gunnar Velle">
+        <sql>
+            UPDATE node n
+            SET contexts = (
+            SELECT jsonb_agg(obj - 'url')
+            FROM jsonb_array_elements(contexts) AS obj
+            )
+            WHERE contexts != '[]'
+        </sql>
+    </changeSet>
+
 
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
@@ -335,7 +335,6 @@ public class NodeTest {
                 "urn:relevance:core",
                 "1",
                 0,
-                Optional.of("/root/f/1"),
                 "urn:connection1");
         var context2 = new TaxonomyContext(
                 root.getPublicId().toString(),
@@ -353,7 +352,6 @@ public class NodeTest {
                 "urn:relevance:core",
                 "2",
                 0,
-                Optional.of("/root/parent1/e/2"),
                 "urn:connection2");
         var context3 = new TaxonomyContext(
                 root.getPublicId().toString(),
@@ -371,7 +369,6 @@ public class NodeTest {
                 "urn:relevance:core",
                 "3",
                 0,
-                Optional.of("/root/parent2/e/3"),
                 "urn:connection3");
 
         node.setContexts(Set.of(context3, context2, context1));

--- a/src/test/java/no/ndla/taxonomy/service/ContextUpdaterServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/ContextUpdaterServiceImplTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,9 +45,6 @@ class ContextUpdaterServiceImplTest extends AbstractIntegrationTest {
         service = new ContextUpdaterServiceImpl();
     }
 
-    @Value(value = "${new.url.separator:false}")
-    private boolean newUrlSeparator;
-
     @Test
     @Transactional
     void updateCachedUrls() {
@@ -73,11 +69,6 @@ class ContextUpdaterServiceImplTest extends AbstractIntegrationTest {
             assertEquals("urn:subject:1", context.rootId());
             assertEquals(0, context.breadcrumbs().size());
             assertTrue(context.isPrimary());
-            if (newUrlSeparator) {
-                assertTrue(context.url().isPresent() && context.url().get().startsWith("/subject1/f/"));
-            } else {
-                assertTrue(context.url().isPresent() && context.url().get().startsWith("/subject1__"));
-            }
 
             var node = nodeRepository.findFirstByPublicId(URI.create("urn:subject:1"));
             assertEquals(1, node.get().getContexts().size());
@@ -99,11 +90,6 @@ class ContextUpdaterServiceImplTest extends AbstractIntegrationTest {
             assertEquals("urn:topic:1", context.rootId().toString());
             assertEquals(0, context.breadcrumbs().size());
             assertTrue(context.isPrimary());
-            if (newUrlSeparator) {
-                assertTrue(context.url().isPresent() && context.url().get().startsWith("/topic1/e/"));
-            } else {
-                assertTrue(context.url().isPresent() && context.url().get().startsWith("/topic1__"));
-            }
 
             var node = nodeRepository.findFirstByPublicId(URI.create("urn:topic:1"));
             assertEquals(1, node.get().getContexts().size());

--- a/src/test/java/no/ndla/taxonomy/service/NodePublishingIntegrationTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodePublishingIntegrationTest.java
@@ -22,7 +22,6 @@ import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.repositories.VersionRepository;
 import no.ndla.taxonomy.rest.v1.commands.VersionPostPut;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -75,7 +74,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         changelogRepository.deleteAll();
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -137,7 +135,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
                 translation -> translation.getName().contains("NB Node"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_with_resource_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -203,7 +200,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
                 resource.getTranslations(), translation -> translation.getName().contains("Resource NN"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_sub_node_with_resource_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -242,7 +238,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(resource.get().getAllPaths(), path -> path.equals("/subject:1/topic:1/resource:1"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_tree_with_resources_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -297,7 +292,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(subsubnode.getAllPaths(), path -> path.equals("/subject:1/topic:2/topic:3"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_tree_with_reused_resource_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -353,7 +347,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(updated.getAllPaths(), path -> path.equals("/subject:1/topic:2/resource:1"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_in_tree_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -402,7 +395,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(updatedChild.getAllPaths(), path -> path.equals("/subject:1/node:1"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_tree_with_reused_resource_twice_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -453,7 +445,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(updated.getAllPaths(), path -> path.equals("/subject:2/topic:2/resource:1"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_reused_resource_with_translations_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -544,7 +535,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
                 updated.getTranslations(), translation -> translation.getName().equals("Resource en"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_twice_to_schema() throws Exception {
         final var command = new VersionPostPut() {
@@ -607,7 +597,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
                 translation -> translation.getName().contains("NB Node updated"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_tree_to_schema_async() throws Exception {
         final var command = new VersionPostPut() {
@@ -659,7 +648,6 @@ public class NodePublishingIntegrationTest extends AbstractIntegrationTest {
         assertAnyTrue(customfields, customfield -> customfield.equals("to be kept"));
     }
 
-    @Test
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     void can_publish_node_tree_with_moved_resource_to_schema() throws Exception {
         final var command = new VersionPostPut() {


### PR DESCRIPTION
Dropper url fra context og genererer heller på direkten i og med at vi må basere oss på språkparameteret.
Med en gong vi er over på nytt url-format fjerner vi flagget, og parameteret `newUrlSeparator`.