### PR TITLE
Fix average calculation bug on deletion

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/GradeAverage.java
+++ b/src/main/java/no/ndla/taxonomy/domain/GradeAverage.java
@@ -33,4 +33,17 @@ public class GradeAverage {
     public int getCount() {
         return count;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        GradeAverage that = (GradeAverage) obj;
+        return Double.compare(that.averageValue, averageValue) == 0 && count == that.count;
+    }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -178,7 +178,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
             var newCount = avg.getCount() - 1;
             var oldSum = (avg.averageValue * avg.getCount());
             var newSum = oldSum - previousGrade.get().toInt();
-            var newAverage = newSum / newCount;
+            var newAverage = newCount > 0 ? newSum / newCount : null;
             this.childQualityEvaluationCount = newCount;
             this.childQualityEvaluationAverage = newAverage;
         } else { // Both grades are present
@@ -190,12 +190,14 @@ public class Node extends DomainObject implements EntityWithMetadata {
         }
     }
 
-    @Transactional
     public void updateEntireAverageTree() {
         var allChildGrades = getChildGradesRecursively();
         var gradeAverage = GradeAverage.fromGrades(allChildGrades);
 
-        if (gradeAverage.count > 0) {
+        if (gradeAverage.count == 0) {
+            this.childQualityEvaluationAverage = null;
+            this.childQualityEvaluationCount = 0;
+        } else if (gradeAverage.count > 0) {
             this.childQualityEvaluationAverage = gradeAverage.averageValue;
             this.childQualityEvaluationCount = gradeAverage.count;
         }

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -18,10 +18,11 @@ import no.ndla.taxonomy.domain.exceptions.DuplicateIdException;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.springframework.transaction.annotation.Transactional;
 
 @Entity
 public class Node extends DomainObject implements EntityWithMetadata {
+    private static final org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(Node.class);
+
     @OneToMany(mappedBy = "child", cascade = CascadeType.ALL, orphanRemoval = true)
     private final Set<NodeConnection> parentConnections = new TreeSet<>();
 
@@ -157,6 +158,15 @@ public class Node extends DomainObject implements EntityWithMetadata {
         }
 
         var avg = childAvg.get();
+
+        if (Double.isNaN(avg.averageValue)) {
+            logger.warn(
+                    "Child quality evaluation average of node '{}' is NaN. Recalculating entire tree.",
+                    this.getPublicId());
+            updateEntireAverageTree();
+            return;
+        }
+
         if (previousGrade.isEmpty() && newGrade.isEmpty()) return;
         else if (previousGrade.isEmpty()) { // New grade is present
             var newCount = avg.getCount() + 1;


### PR DESCRIPTION
Fikser buggen som oppstod dersom man oppdaterte en karakter og slettet den igjen uten å gi noen andre karakterer i faget / topic'en.

Var en dele på null feil som resulterte i at `NaN` ble lagret i databasen.
Fikser det + legger til en liten fallback dersom vi finner `NaN` som regner ut hele treet på nytt (Dette tar lang tid så forhåpentligvis skjer det ikke igjen, men tror det er trygt å ha fallbacken når man driver med regning i java :nerd_face: ).