### PR TITLE
Fix warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ EXPOSE 5000
 COPY --from=0 /src/target/taxonomy-service.jar /app.jar
 COPY ./run-app.sh /run-app.sh
 
-ENV RUNNING_IN_DOCKER true
+ENV RUNNING_IN_DOCKER=true
 
 ENTRYPOINT [ "/run-app.sh" ]

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>21</java.version>
-        <javamelody.version>2.1.0</javamelody.version>
+        <javamelody.version>2.2.0</javamelody.version>
         <spotless.version>2.43.0</spotless.version>
         <postgresql.version>42.7.2</postgresql.version>
         <testcontainers.version>1.19.7</testcontainers.version>

--- a/src/main/java/no/ndla/taxonomy/TaxonomyApplication.java
+++ b/src/main/java/no/ndla/taxonomy/TaxonomyApplication.java
@@ -9,8 +9,9 @@ package no.ndla.taxonomy;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = {UserDetailsServiceAutoConfiguration.class})
 public class TaxonomyApplication {
     public static void main(String[] args) {
         SpringApplication.run(TaxonomyApplication.class, args);

--- a/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
+++ b/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
@@ -15,6 +15,7 @@ import ch.qos.logback.core.spi.FilterReply;
 public class WarningSuppressionLogFilter extends Filter<ILoggingEvent> {
 
     final String[] warningsToSuppress = {
+            // https://github.com/javamelody/javamelody/issues/1222
             "Bean 'net.bull.javamelody.JavaMelodyAutoConfiguration' of type [net.bull.javamelody.JavaMelodyAutoConfiguration$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors",
             "Bean 'monitoringSpringAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
             "Bean 'monitoringSpringServiceAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
@@ -22,6 +23,7 @@ public class WarningSuppressionLogFilter extends Filter<ILoggingEvent> {
             "Bean 'monitoringSpringRestControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
             "Bean 'monitoringSpringAsyncAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
             "Bean 'monitoringSpringScheduledAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            // NOTE: These are logged because we use `runAlways=true` in the liquibase configuration
             "schema \"extensions\" already exists, skipping",
             "extension \"btree_gist\" already exists, skipping",
     };

--- a/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
+++ b/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
@@ -1,0 +1,42 @@
+/*
+ * Part of NDLA taxonomy-api
+ * Copyright (C) 2024 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.taxonomy.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.filter.Filter;
+import ch.qos.logback.core.spi.FilterReply;
+
+public class WarningSuppressionLogFilter extends Filter<ILoggingEvent> {
+
+    final String[] warningsToSuppress = {
+            "Bean 'net.bull.javamelody.JavaMelodyAutoConfiguration' of type [net.bull.javamelody.JavaMelodyAutoConfiguration$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringServiceAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringRestControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringAsyncAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "Bean 'monitoringSpringScheduledAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+            "schema \"extensions\" already exists, skipping",
+            "extension \"btree_gist\" already exists, skipping",
+    };
+
+
+    @Override
+    public FilterReply decide(ILoggingEvent event) {
+        if (event.getLevel() == Level.WARN) {
+            var eventMessage = event.getMessage();
+            for (var msg : warningsToSuppress) {
+                if (eventMessage.contains(msg)) {
+                    return FilterReply.DENY;
+                }
+            }
+        }
+        return FilterReply.ACCEPT;
+    }
+}

--- a/src/main/java/no/ndla/taxonomy/domain/JsonTranslation.java
+++ b/src/main/java/no/ndla/taxonomy/domain/JsonTranslation.java
@@ -71,4 +71,9 @@ public class JsonTranslation implements Serializable, Translation {
         return Objects.equals(this.getLanguageCode(), that.getLanguageCode())
                 && Objects.equals(this.getName(), that.getName());
     }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getName(), this.getLanguageCode());
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ spring:
     properties:
       hibernate:
         globally_quoted_identifiers: true
+    open-in-view: false
   liquibase:
     change-log: classpath:db-master-changelog.xml
     parameters:

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -4,6 +4,7 @@
 
     <springProfile name="docker">
         <appender name="DOCKER" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="no.ndla.taxonomy.config.WarningSuppressionLogFilter"/>
             <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
                 <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
                     <appendLineSeparator>true</appendLineSeparator>
@@ -20,7 +21,16 @@
     </springProfile>
 
     <springProfile name="!docker">
-        <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+                <level>${CONSOLE_LOG_THRESHOLD}</level>
+            </filter>
+            <filter class="no.ndla.taxonomy.config.WarningSuppressionLogFilter"/>
+            <encoder>
+                <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+                <charset>${CONSOLE_LOG_CHARSET}</charset>
+            </encoder>
+        </appender>
         <root level="INFO">
             <appender-ref ref="CONSOLE"/>
         </root>


### PR DESCRIPTION
Fikser litt div warnings.
Nå som vi teller warnings så hadde det vært kult å fått den ned til 0 sånn at vi faktisk kan se "oi nå er det warnings vi må fikse".

Jeg vet det står igjen disse:

```
liquibase.executor: schema "extensions" already exists, skipping
liquibase.executor: extension "btree_gist" already exists, skipping
```

Ser ut som det er fordi `runAlways="true"` i changelog'en. Husker noen hvorfor vi har det?