### PR TITLE
Adds rootId and parentId when fetching nodes to pick correct context

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
+++ b/src/main/java/no/ndla/taxonomy/config/WarningSuppressionLogFilter.java
@@ -15,19 +15,18 @@ import ch.qos.logback.core.spi.FilterReply;
 public class WarningSuppressionLogFilter extends Filter<ILoggingEvent> {
 
     final String[] warningsToSuppress = {
-            // https://github.com/javamelody/javamelody/issues/1222
-            "Bean 'net.bull.javamelody.JavaMelodyAutoConfiguration' of type [net.bull.javamelody.JavaMelodyAutoConfiguration$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringServiceAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringRestControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringAsyncAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            "Bean 'monitoringSpringScheduledAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
-            // NOTE: These are logged because we use `runAlways=true` in the liquibase configuration
-            "schema \"extensions\" already exists, skipping",
-            "extension \"btree_gist\" already exists, skipping",
+        // https://github.com/javamelody/javamelody/issues/1222
+        "Bean 'net.bull.javamelody.JavaMelodyAutoConfiguration' of type [net.bull.javamelody.JavaMelodyAutoConfiguration$$SpringCGLIB$$0] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringServiceAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringRestControllerAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringAsyncAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        "Bean 'monitoringSpringScheduledAdvisor' of type [net.bull.javamelody.MonitoringSpringAdvisor] is not eligible for getting processed by all BeanPostProcessors",
+        // NOTE: These are logged because we use `runAlways=true` in the liquibase configuration
+        "schema \"extensions\" already exists, skipping",
+        "extension \"btree_gist\" already exists, skipping",
     };
-
 
     @Override
     public FilterReply decide(ILoggingEvent event) {

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -254,17 +254,15 @@ public class Node extends DomainObject implements EntityWithMetadata {
         if (maybeContext.isPresent()) {
             return maybeContext;
         }
-        var withParent = parent.map(p -> contexts.stream()
+        var containsParent = parent.map(p -> contexts.stream()
                         .filter(c -> c.parentIds().contains(p.getPublicId().toString()))
                         .collect(Collectors.toSet()))
                 .orElse(contexts);
-        var withRoot = root.flatMap(r -> withParent.stream()
-                .filter(c -> c.rootId().equals(r.getPublicId().toString()))
-                .findFirst());
-        if (withRoot.isPresent()) {
-            return withRoot;
-        }
-        return contexts.stream().min((context1, context2) -> {
+        var containsRoot = root.map(p -> containsParent.stream()
+                        .filter(c -> c.parentIds().contains(p.getPublicId().toString()))
+                        .collect(Collectors.toSet()))
+                .orElse(containsParent);
+        return containsRoot.stream().min((context1, context2) -> {
             final var inPath1 =
                     context1.path().contains(root.map(Node::getPathPart).orElse("other"));
             final var inPath2 =

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -232,10 +232,16 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<URI> rootId,
             @Parameter(description = "Id to parent id in context.") @RequestParam(value = "parentId", required = false)
                     Optional<URI> parentId,
+            @Parameter(name = "includeContexts", description = "Include all contexts")
+                    @RequestParam(value = "includeContexts", required = false, defaultValue = "true")
+                    Optional<Boolean> includeContexts,
+            @Parameter(description = "Filter out programme contexts")
+                    @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
+                    boolean filterProgrammes,
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(true), rootId, parentId);
+        return nodeService.getNode(id, language, rootId, parentId, includeContexts, filterProgrammes);
     }
 
     @PostMapping

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -110,13 +110,17 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")
                     @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
-                    boolean filterProgrammes) {
+                    boolean filterProgrammes,
+            @Parameter(description = "Id to root id in context.") @RequestParam(value = "rootId", required = false)
+                    Optional<URI> rootId,
+            @Parameter(description = "Id to parent id in context.") @RequestParam(value = "parentId", required = false)
+                    Optional<URI> parentId) {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         var isRootOrContext = isRoot.isPresent() ? isRoot : isContext;
         var defaultNodeTypes = getDefaultNodeTypes(nodeType, contentUri, contextId, isRootOrContext, metadataFilters);
         return nodeService.getNodesByType(
                 Optional.of(defaultNodeTypes),
-                language,
+                language.orElse(Constants.DefaultLanguage),
                 publicIds,
                 contentUri,
                 contextId,
@@ -124,7 +128,9 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                 isContext,
                 metadataFilters,
                 includeContexts,
-                filterProgrammes);
+                filterProgrammes,
+                rootId,
+                parentId);
     }
 
     @GetMapping("/search")
@@ -222,10 +228,14 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
     @Transactional(readOnly = true)
     public NodeDTO getNode(
             @PathVariable("id") URI id,
+            @Parameter(description = "Id to root id in context.") @RequestParam(value = "rootId", required = false)
+                    Optional<URI> rootId,
+            @Parameter(description = "Id to parent id in context.") @RequestParam(value = "parentId", required = false)
+                    Optional<URI> parentId,
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(true));
+        return nodeService.getNode(id, language, Optional.of(true), rootId, parentId);
     }
 
     @PostMapping

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -83,7 +83,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         return nodeService.getNodesByType(
                 Optional.of(List.of(NodeType.RESOURCE)),
-                language,
+                language.orElse(Constants.DefaultLanguage),
                 Optional.empty(),
                 contentUri,
                 Optional.empty(),
@@ -91,7 +91,9 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 metadataFilters,
                 Optional.of(false),
-                false);
+                false,
+                Optional.empty(),
+                Optional.empty());
     }
 
     @Deprecated
@@ -167,7 +169,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false));
+        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -169,7 +169,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -80,7 +80,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         return nodeService.getNodesByType(
                 Optional.of(List.of(NodeType.SUBJECT)),
-                language,
+                language.orElse(Constants.DefaultLanguage),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -88,7 +88,9 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 metadataFilters,
                 Optional.of(false),
-                false);
+                false,
+                Optional.empty(),
+                Optional.empty());
     }
 
     @Deprecated
@@ -167,7 +169,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false));
+        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -169,7 +169,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -153,7 +153,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -68,7 +68,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
         MetadataFilters metadataFilters = new MetadataFilters(key, value, isVisible);
         return nodeService.getNodesByType(
                 Optional.of(List.of(NodeType.TOPIC)),
-                language,
+                language.orElse(Constants.DefaultLanguage),
                 Optional.empty(),
                 contentUri,
                 Optional.empty(),
@@ -76,7 +76,9 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 Optional.empty(),
                 metadataFilters,
                 Optional.of(false),
-                false);
+                false,
+                Optional.empty(),
+                Optional.empty());
     }
 
     @Deprecated
@@ -151,7 +153,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.of(false));
+        return nodeService.getNode(id, language, Optional.of(false), Optional.empty(), Optional.empty());
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -169,9 +169,10 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
     public NodeDTO getNode(
             URI publicId,
             Optional<String> language,
-            Optional<Boolean> includeContexts,
             Optional<URI> rootId,
-            Optional<URI> parentId) {
+            Optional<URI> parentId,
+            Optional<Boolean> includeContexts,
+            boolean filterProgrammes) {
         var node = getNode(publicId);
         var root = rootId.map(this::getNode);
         var parent = parentId.map(this::getNode);
@@ -182,7 +183,7 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                 language.orElse(Constants.DefaultLanguage),
                 Optional.empty(),
                 includeContexts,
-                false,
+                filterProgrammes,
                 newUrlSeparator);
     }
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -106,11 +106,6 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
 
     public NodeChildDTO() {}
 
-    @Deprecated
-    public URI getParent() {
-        return parentId;
-    }
-
     public URI getParentId() {
         return parentId;
     }
@@ -129,11 +124,6 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
 
     @JsonProperty("isPrimary")
     public boolean isPrimary() {
-        return isPrimary;
-    }
-
-    @Deprecated
-    public boolean getPrimary() {
         return isPrimary;
     }
 

--- a/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
@@ -403,7 +403,7 @@ public class NodeTest extends AbstractIntegrationTest {
             assertEquals(context3.contextId(), context.get().contextId());
         }
         {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.empty(), Optional.empty(), Optional.of(node));
+            Optional<TaxonomyContext> context = node.pickContext(Optional.empty(), Optional.empty(), Optional.empty());
             assertEquals(context1.contextId(), context.get().contextId());
         }
         {

--- a/typescript/taxonomy-api.ts
+++ b/typescript/taxonomy-api.ts
@@ -33,6 +33,10 @@ export interface Node {
     breadcrumbs: string[];
     contentUri?: string;
     /**
+     * The context object selected when fetching node
+     */
+    context?: TaxonomyContext;
+    /**
      * An id unique for this context.
      */
     contextId?: string;
@@ -65,10 +69,6 @@ export interface Node {
 export interface NodeChild extends Node {
     connectionId: string;
     isPrimary: boolean;
-    /**
-     * @deprecated
-     */
-    parent: string;
     parentId: string;
     rank: number;
 }


### PR DESCRIPTION
I graphql-api så henter vi node med rootId og parentId, men disse brukes for å filtrere kontekster i etterkant. Ved å sende inn verdiene her kan vi la taksonomi gjøre jobben for oss. Legger også til et par ekstra parametere ved uthenting av enkeltnode som gjør at vi kan styre litt meir om kva vi henter ut av data. 

Tidligere har henting av enkeltnode gitt oss en standard-path tilbake, tilsvarende korteste url i kontekst, men med denne endringa kan vi spesifisere ekstraparameter til urlen som kjem tilbake. Legger på et eget kontekstobjekt som peiker på valgt kontekst for å forenkle graphql-koden litt til.

