### PR TITLE
Returner kun aktive/synlige kontekster som standard

### DIFF
--- a/run-app.sh
+++ b/run-app.sh
@@ -10,4 +10,4 @@ if [[ "$RUNNING_IN_DOCKER" = "true" ]]; then
   fi
 fi
 
-java -Xmx${HEAPSPACE_MAX:-"1000m"} --add-exports java.desktop/sun.font=ALL-UNNAMED -jar /app.jar
+java -Xmx${HEAPSPACE_MAX:-"2G"} -Xms${HEAPSPACE_MAX:-"2G"} --add-exports java.desktop/sun.font=ALL-UNNAMED -jar /app.jar

--- a/src/main/java/no/ndla/taxonomy/config/WebSecurityConfig.java
+++ b/src/main/java/no/ndla/taxonomy/config/WebSecurityConfig.java
@@ -10,7 +10,7 @@ package no.ndla.taxonomy.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -21,7 +21,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Profile("auth")
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true, prePostEnabled = true)
+@EnableMethodSecurity(securedEnabled = true)
 public class WebSecurityConfig {
 
     @Bean

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -78,11 +78,12 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
             SELECT DISTINCT n FROM Node n
             LEFT JOIN FETCH n.resourceResourceTypes rrt
             LEFT JOIN FETCH rrt.resourceType
+            LEFT JOIN FETCH n.parentConnections pc
             LEFT JOIN FETCH n.childConnections cc
-            WHERE n.nodeType = "SUBJECT"
+            WHERE n.nodeType = "PROGRAMME"
             AND n.context = true
             """)
-    List<Node> findSubjectRoots();
+    List<Node> findProgrammes();
 
     @Query(
             """

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import no.ndla.taxonomy.service.NodeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -31,7 +30,6 @@ public class Admin {
     @Operation(
             summary = "Updates contexts for all roots. Requires taxonomy:admin access.",
             security = {@SecurityRequirement(name = "oauth")})
-    @Transactional
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
     public void buildAllContexts() {

--- a/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/NodeResources.java
@@ -44,9 +44,9 @@ public class NodeResources extends CrudControllerWithMetadata<NodeConnection> {
             NodeRepository nodeRepository,
             NodeConnectionService connectionService,
             NodeConnectionRepository nodeConnectionRepository,
-            ContextUpdaterService cachedUrlUpdaterService,
+            ContextUpdaterService contextUpdaterService,
             NodeService nodeService) {
-        super(nodeConnectionRepository, cachedUrlUpdaterService, nodeService);
+        super(nodeConnectionRepository, contextUpdaterService, nodeService);
         this.nodeConnectionRepository = nodeConnectionRepository;
         this.nodeRepository = nodeRepository;
         this.connectionService = connectionService;

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -49,10 +49,10 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
             NodeRepository nodeRepository,
             NodeConnectionRepository nodeConnectionRepository,
             NodeService nodeService,
-            ContextUpdaterService cachedUrlUpdaterService,
+            ContextUpdaterService contextUpdaterService,
             RecursiveNodeTreeService recursiveNodeTreeService,
             TreeSorter treeSorter) {
-        super(nodeRepository, cachedUrlUpdaterService, nodeService);
+        super(nodeRepository, contextUpdaterService, nodeService);
 
         this.nodeRepository = nodeRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
@@ -204,7 +204,10 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")
                     @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
-                    boolean filterProgrammes) {
+                    boolean filterProgrammes,
+            @Parameter(description = "Only visible contexts")
+                    @RequestParam(value = "isVisible", required = false, defaultValue = "true")
+                    boolean isVisible) {
         if (page.isEmpty() || pageSize.isEmpty()) {
             throw new IllegalArgumentException("Need both page and pageSize to return data");
         }
@@ -221,6 +224,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                         Optional.empty(),
                         includeContexts,
                         filterProgrammes,
+                        isVisible,
                         newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
@@ -239,12 +243,15 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "includeContexts", required = false, defaultValue = "true")
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")
-                    @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
+                    @RequestParam(value = "filterProgrammes", required = false, defaultValue = "true")
                     boolean filterProgrammes,
+            @Parameter(description = "Only visible contexts")
+                    @RequestParam(value = "isVisible", required = false, defaultValue = "true")
+                    boolean isVisible,
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, rootId, parentId, includeContexts, filterProgrammes);
+        return nodeService.getNode(id, language, rootId, parentId, includeContexts, filterProgrammes, isVisible);
     }
 
     @PostMapping
@@ -317,7 +324,10 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<Boolean> includeContexts,
             @Parameter(description = "Filter out programme contexts")
                     @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
-                    boolean filterProgrammes) {
+                    boolean filterProgrammes,
+            @Parameter(description = "Only visible contexts")
+                    @RequestParam(value = "isVisible", required = false, defaultValue = "true")
+                    boolean isVisible) {
         final var node = nodeRepository.findFirstByPublicId(id).orElseThrow(() -> new NotFoundException("Node", id));
 
         final List<URI> childrenIds;
@@ -352,6 +362,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                         language.orElse(Constants.DefaultLanguage),
                         includeContexts,
                         filterProgrammes,
+                        isVisible,
                         newUrlSeparator))
                 .forEach(returnList::add);
 
@@ -397,6 +408,9 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "Filter out programme contexts")
                     @RequestParam(value = "filterProgrammes", required = false, defaultValue = "false")
                     boolean filterProgrammes,
+            @Parameter(description = "Only visible contexts")
+                    @RequestParam(value = "isVisible", required = false, defaultValue = "true")
+                    boolean isVisible,
             @Parameter(description = "If true, resources from children are fetched recursively")
                     @RequestParam(value = "recursive", required = false, defaultValue = "false")
                     boolean recursive,
@@ -411,7 +425,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                     Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                nodeId, resourceTypeIds, relevance, language, recursive, includeContexts, filterProgrammes);
+                nodeId, resourceTypeIds, relevance, language, recursive, includeContexts, filterProgrammes, isVisible);
     }
 
     @GetMapping("{id}/full")

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -49,9 +49,9 @@ public class Resources extends CrudControllerWithMetadata<Node> {
     public Resources(
             NodeRepository nodeRepository,
             ResourceResourceTypeRepository resourceResourceTypeRepository,
-            ContextUpdaterService cachedUrlUpdaterService,
+            ContextUpdaterService contextUpdaterService,
             NodeService nodeService) {
-        super(nodeRepository, cachedUrlUpdaterService, nodeService);
+        super(nodeRepository, contextUpdaterService, nodeService);
 
         this.resourceResourceTypeRepository = resourceResourceTypeRepository;
         this.repository = nodeRepository;
@@ -155,6 +155,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                         Optional.empty(),
                         Optional.of(false),
                         false,
+                        false,
                         newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
@@ -169,7 +170,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false, true);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -49,12 +49,12 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
 
     public Subjects(
             TreeSorter treeSorter,
-            ContextUpdaterService cachedUrlUpdaterService,
+            ContextUpdaterService contextUpdaterService,
             RecursiveNodeTreeService recursiveNodeTreeService,
             NodeService nodeService,
             NodeRepository nodeRepository,
             NodeConnectionRepository nodeConnectionRepository) {
-        super(nodeRepository, cachedUrlUpdaterService, nodeService);
+        super(nodeRepository, contextUpdaterService, nodeService);
 
         this.topicTreeSorter = treeSorter;
         this.recursiveNodeTreeService = recursiveNodeTreeService;
@@ -153,6 +153,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         Optional.empty(),
                         Optional.of(false),
                         false,
+                        false,
                         newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
@@ -169,7 +170,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false, true);
     }
 
     @Deprecated
@@ -261,6 +262,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                         language.orElse(Constants.DefaultLanguage),
                         Optional.of(false),
                         false,
+                        true,
                         newUrlSeparator))
                 .forEach(returnList::add);
 
@@ -341,6 +343,6 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                     Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                subjectId, resourceTypeIds, relevance, language, true, Optional.of(false), false);
+                subjectId, resourceTypeIds, relevance, language, true, Optional.of(false), false, true);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -40,9 +40,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
     @Value(value = "${new.url.separator:false}")
     private boolean newUrlSeparator;
 
-    public Topics(
-            NodeRepository nodeRepository, NodeService nodeService, ContextUpdaterService cachedUrlUpdaterService) {
-        super(nodeRepository, cachedUrlUpdaterService, nodeService);
+    public Topics(NodeRepository nodeRepository, NodeService nodeService, ContextUpdaterService contextUpdaterService) {
+        super(nodeRepository, contextUpdaterService, nodeService);
 
         this.nodeRepository = nodeRepository;
         this.nodeService = nodeService;
@@ -139,6 +138,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                         Optional.empty(),
                         Optional.of(false),
                         false,
+                        false,
                         newUrlSeparator))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
@@ -153,7 +153,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ISO-639-1 language code", example = "nb")
                     @RequestParam(value = "language", required = false, defaultValue = Constants.DefaultLanguage)
                     Optional<String> language) {
-        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false);
+        return nodeService.getNode(id, language, Optional.empty(), Optional.empty(), Optional.of(false), false, true);
     }
 
     @Deprecated
@@ -248,7 +248,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                     Optional<URI> relevance) {
 
         return nodeService.getResourcesByNodeId(
-                topicId, resourceTypeIds, relevance, language, recursive, Optional.of(false), false);
+                topicId, resourceTypeIds, relevance, language, recursive, Optional.of(false), false, true);
     }
 
     @Deprecated

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -55,9 +55,9 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                             .map(parentContext -> {
                                 var breadcrumbs = LanguageField.listFromLists(
                                         parentContext.breadcrumbs(), LanguageField.fromNode(parent));
-                                List<String> parentIds = parentContext.parentIds();
+                                var parentIds = parentContext.parentIds();
                                 parentIds.add(parent.getPublicId().toString());
-                                List<String> parentContextIds = parentContext.parentContextIds();
+                                var parentContextIds = parentContext.parentContextIds();
                                 parentContextIds.add(parentContext.contextId());
                                 var contextId =
                                         HashUtil.mediumHash(parentContext.contextId() + parentConnection.getPublicId());

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -47,6 +47,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
             String language,
             Optional<Boolean> includeContexts,
             boolean filterProgrammes,
+            boolean isVisible,
             boolean newUrlSeparator) {
         super(
                 root,
@@ -56,6 +57,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 Optional.empty(),
                 includeContexts,
                 filterProgrammes,
+                isVisible,
                 newUrlSeparator);
 
         // This must be enabled when ed is updated to update metadata for connections.
@@ -84,6 +86,7 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 Optional.empty(),
                 Optional.of(false),
                 false,
+                true,
                 newUrlSeparator);
 
         this.rank = nodeConnection.getRank();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -29,7 +29,16 @@ public class NodeWithParents extends NodeDTO {
     public NodeWithParents() {}
 
     public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts, boolean newUrlSeparator) {
-        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts, false, false);
+        super(
+                Optional.empty(),
+                Optional.empty(),
+                node,
+                languageCode,
+                Optional.empty(),
+                includeContexts,
+                false,
+                true,
+                false);
 
         node.getParentConnections().stream()
                 .map(nodeResource -> {

--- a/src/test/java/no/ndla/taxonomy/TestSeeder.java
+++ b/src/test/java/no/ndla/taxonomy/TestSeeder.java
@@ -147,9 +147,11 @@ public class TestSeeder {
             nodeResource.setRank(rank);
         }
 
+        nodeConnectionRepository.saveAndFlush(nodeResource);
+
         nodeResource.getParent().ifPresent(cachedUrlUpdaterService::updateContexts);
 
-        return nodeConnectionRepository.saveAndFlush(nodeResource);
+        return nodeResource;
     }
 
     private void clearAll() {

--- a/src/test/java/no/ndla/taxonomy/rest/v1/ContextsTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/ContextsTest.java
@@ -32,11 +32,9 @@ public class ContextsTest extends RestTest {
 
     @Test
     public void all_subjects_are_contexts() throws Exception {
-        nodeRepository.flush();
-
         builder.node(s -> s.nodeType(NodeType.SUBJECT)
-                .isContext(true)
                 .publicId("urn:subject:1")
+                .isContext(true)
                 .name("Subject 1"));
 
         var response = testUtils.getResource("/v1/contexts");

--- a/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/RestTest.java
@@ -56,7 +56,7 @@ public abstract class RestTest extends AbstractIntegrationTest {
     protected TestUtils testUtils;
 
     @Autowired
-    protected ContextUpdaterService cachedUrlUpdaterService;
+    protected ContextUpdaterService contextUpdaterService;
 
     protected Builder builder;
 
@@ -76,7 +76,7 @@ public abstract class RestTest extends AbstractIntegrationTest {
     @SuppressWarnings("unchecked")
     @BeforeEach
     public void restTestSetUp() {
-        builder = new Builder(entityManager, cachedUrlUpdaterService);
+        builder = new Builder(entityManager, contextUpdaterService);
         nodeRepository.deleteAllAndFlush();
         nodeConnectionRepository.deleteAllAndFlush();
     }


### PR DESCRIPTION
Endrer litt på henting av kontekster slik at usynlige kontekster skjules når du henter enkeltnoder.
Dette skal ikkje påvirke vanlig bruk av taksonomi, så vidt eg kan sjå.