### PR TITLE
Make quality evaluation tree updating recursive

### DIFF
--- a/src/main/java/no/ndla/taxonomy/config/WebSecurityConfig.java
+++ b/src/main/java/no/ndla/taxonomy/config/WebSecurityConfig.java
@@ -11,7 +11,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -235,6 +235,11 @@ public class Node extends DomainObject implements EntityWithMetadata {
     public void updateEntireAverageTree() {
         var allChildGrades = getChildGradesRecursively();
         var gradeAverage = GradeAverage.fromGrades(allChildGrades);
+        logger.info(
+                "Found average grades for {} children of node '{}' -> {}",
+                allChildGrades.size(),
+                this.getPublicId(),
+                gradeAverage);
 
         if (gradeAverage.count == 0) {
             this.childQualityEvaluationAverage = null;
@@ -251,10 +256,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
                 .flatMap(child -> {
                     ArrayList<Optional<Grade>> childGrades = new ArrayList<>(child.getChildGradesRecursively());
                     if (child.nodeType == NodeType.RESOURCE) {
-                        var grade = child.getQualityEvaluationGrade();
-                        grade.ifPresent(
-                                value -> logger.info("Found grade {} for resource {}", value, child.getPublicId()));
-                        childGrades.add(grade);
+                        childGrades.add(child.getQualityEvaluationGrade());
                     }
                     return childGrades.stream();
                 })

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -251,7 +251,10 @@ public class Node extends DomainObject implements EntityWithMetadata {
                 .flatMap(child -> {
                     ArrayList<Optional<Grade>> childGrades = new ArrayList<>(child.getChildGradesRecursively());
                     if (child.nodeType == NodeType.RESOURCE) {
-                        childGrades.add(child.getQualityEvaluationGrade());
+                        var grade = child.getQualityEvaluationGrade();
+                        grade.ifPresent(
+                                value -> logger.info("Found grade {} for resource {}", value, child.getPublicId()));
+                        childGrades.add(grade);
                     }
                     return childGrades.stream();
                 })

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -38,6 +38,15 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
 
     @Query(
             """
+            SELECT n.id
+            FROM Node n
+            LEFT JOIN n.childConnections cc
+            WHERE cc IS NOT NULL
+            """)
+    List<Integer> findIdsWithChildren();
+
+    @Query(
+            """
             SELECT n.id FROM Node n
             LEFT JOIN n.parentConnections pc
             WHERE ((:#{#nodeTypes == null} = true) OR n.nodeType in (:nodeTypes))

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
@@ -39,10 +39,19 @@ public class Admin {
 
     @PostMapping("/buildAverageTree/{id}")
     @Operation(
-            summary = "Updates average tree for all nodes. Requires taxonomy:admin access.",
+            summary = "Updates average tree for the provided node. Requires taxonomy:admin access.",
             security = {@SecurityRequirement(name = "oauth")})
     @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
     public void buildAverageTree(@PathVariable("id") URI id) {
         qualityEvaluationService.updateEntireAverageTreeForNode(id);
+    }
+
+    @PostMapping("/buildAverageTree")
+    @Operation(
+            summary = "Updates average tree for all nodes. Requires taxonomy:admin access.",
+            security = {@SecurityRequirement(name = "oauth")})
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
+    public void buildAverageTree() {
+        qualityEvaluationService.updateQualityEvaluationOfAllNodes();
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
@@ -9,13 +9,12 @@ package no.ndla.taxonomy.rest.v1;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import java.net.URI;
 import no.ndla.taxonomy.service.NodeService;
 import no.ndla.taxonomy.service.QualityEvaluationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-
-import java.net.URI;
 
 @RestController
 @RequestMapping(path = {"/v1/admin"})

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Admin.java
@@ -10,20 +10,22 @@ package no.ndla.taxonomy.rest.v1;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import no.ndla.taxonomy.service.NodeService;
+import no.ndla.taxonomy.service.QualityEvaluationService;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping(path = {"/v1/admin"})
 public class Admin {
     private final NodeService nodeService;
+    private final QualityEvaluationService qualityEvaluationService;
 
-    public Admin(NodeService nodeService) {
+    public Admin(NodeService nodeService, QualityEvaluationService qualityEvaluationService) {
         this.nodeService = nodeService;
+        this.qualityEvaluationService = qualityEvaluationService;
     }
 
     @GetMapping("/buildContexts")
@@ -34,5 +36,14 @@ public class Admin {
     @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
     public void buildAllContexts() {
         nodeService.buildAllContextsAsync();
+    }
+
+    @PostMapping("/buildAverageTree/{id}")
+    @Operation(
+            summary = "Updates average tree for all nodes. Requires taxonomy:admin access.",
+            security = {@SecurityRequirement(name = "oauth")})
+    @PreAuthorize("hasAuthority('TAXONOMY_ADMIN')")
+    public void buildAverageTree(@PathVariable("id") URI id) {
+        qualityEvaluationService.updateEntireAverageTreeForNode(id);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -113,4 +113,13 @@ public class QualityEvaluationService {
             updateQualityEvaluationOfRecursive(parentsParents, oldGrade, newGrade);
         }));
     }
+
+
+    @Transactional
+    public void updateEntireAverageTreeForNode(URI publicId) {
+        var node = nodeRepository.findFirstByPublicId(publicId)
+                .orElseThrow(() -> new NotFoundServiceException("Node was not found"));
+        node.updateEntireAverageTree();
+        nodeRepository.save(node);
+    }
 }

--- a/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
+++ b/src/main/java/no/ndla/taxonomy/service/QualityEvaluationService.java
@@ -61,18 +61,14 @@ public class QualityEvaluationService {
                 .ifPresent(childAverage -> addGradeAverageTreeToParents(parent, childAverage));
     }
 
-    protected void addGradeAverageTreeToParents(Node node, GradeAverage averageToAdd) {
+    private void addGradeAverageTreeToParents(Node node, GradeAverage averageToAdd) {
         node.addGradeAverageTreeToAverageCalculation(averageToAdd);
-        node.getParentNodes().forEach(parent -> {
-            addGradeAverageTreeToParents(parent, averageToAdd);
-        });
+        node.getParentNodes().forEach(parent -> addGradeAverageTreeToParents(parent, averageToAdd));
     }
 
-    protected void removeGradeAverageTreeFromParents(Node node, GradeAverage averageToRemove) {
+    private void removeGradeAverageTreeFromParents(Node node, GradeAverage averageToRemove) {
         node.removeGradeAverageTreeFromAverageCalculation(averageToRemove);
-        node.getParentNodes().forEach(parent -> {
-            removeGradeAverageTreeFromParents(parent, averageToRemove);
-        });
+        node.getParentNodes().forEach(parent -> removeGradeAverageTreeFromParents(parent, averageToRemove));
     }
 
     public void removeQualityEvaluationOfDeletedConnection(NodeConnection connectionToDelete) {


### PR DESCRIPTION
Denne legger til to endepunkter:
- `/v1/admin/buildAverageTree/{id}` Regner ut quality evaluation gjennomsnittet for noden med <id>
- `/v1/admin/buildAverageTree` Regner ut quality evaluation gjennomsnittet for alle noder som har barn

Oooog det viktigste: utregninger på parents ved flytting av topics er nå rekursive.
Tidligere så hvis man flyttet en topic som inneholdt ressurser så ble ikke det tatt med i utregningen på parents av parenten, det var jo litt dumt :smirk_cat: 