### PR TITLE
Calculate parents on the fly

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -484,7 +484,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
                 .map(NodeConnection::getParent)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public Collection<Node> getResources() {

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -484,7 +484,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
                 .map(NodeConnection::getParent)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     public Collection<Node> getResources() {
@@ -494,6 +494,20 @@ public class Node extends DomainObject implements EntityWithMetadata {
                 .map(Optional::get)
                 .filter(s -> s.getNodeType() == NodeType.RESOURCE)
                 .toList();
+    }
+
+    private Collection<Node> getAllParentsRecursive() {
+        var parents = getParentNodes();
+        ArrayList<Node> all = new ArrayList<>(parents);
+        parents.forEach(parent -> all.addAll(parent.getAllParentsRecursive()));
+        return all;
+    }
+
+    public Collection<TaxonomyContext> getAllParentContexts() {
+        return getAllParentsRecursive().stream()
+                .map(Node::getContexts)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toSet());
     }
 
     public void setIdent(String ident) {

--- a/src/main/java/no/ndla/taxonomy/domain/TaxonomyContext.java
+++ b/src/main/java/no/ndla/taxonomy/domain/TaxonomyContext.java
@@ -15,7 +15,9 @@ import java.util.Optional;
  * Identifies a unique context for any node. A context is a position for a node in the structure, identified by root
  * node and parent-connection
  *
+ * @param publicId         The publicId of the node.
  * @param name             The name of the node.
+ * @param nodeType         The type of the node.
  * @param rootId           The publicId of the node at the root of the context.
  * @param rootName         The name of the root.
  * @param path             The path for this connection.
@@ -30,11 +32,12 @@ import java.util.Optional;
  * @param contextId        Hash of root publicId + nodeConnection publicId. Unique for this context.
  * @param rank             The rank of the context. From nodeConnection.
  * @param connectionId     The id of the connection. From nodeConnection.
- * @param parents          The parents of the context.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TaxonomyContext(
+        String publicId,
         LanguageField<String> name,
+        NodeType nodeType,
         String rootId,
         LanguageField<String> rootName,
         String path,
@@ -48,5 +51,4 @@ public record TaxonomyContext(
         String relevanceId,
         String contextId,
         int rank,
-        String connectionId,
-        List<TaxonomyCrumb> parents) {}
+        String connectionId) {}

--- a/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/ContextUpdaterServiceImpl.java
@@ -9,7 +9,10 @@ package no.ndla.taxonomy.service;
 
 import java.util.*;
 import no.ndla.taxonomy.config.Constants;
-import no.ndla.taxonomy.domain.*;
+import no.ndla.taxonomy.domain.LanguageField;
+import no.ndla.taxonomy.domain.Node;
+import no.ndla.taxonomy.domain.Relevance;
+import no.ndla.taxonomy.domain.TaxonomyContext;
 import no.ndla.taxonomy.util.HashUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -30,7 +33,9 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
         if (node.isContext()) {
             var contextId = HashUtil.semiHash(node.getPublicId());
             returnedContexts.add(new TaxonomyContext(
+                    node.getPublicId().toString(),
                     LanguageField.fromNode(node),
+                    node.getNodeType(),
                     node.getPublicId().toString(),
                     LanguageField.fromNode(node),
                     node.getPathPart(),
@@ -44,8 +49,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                     Relevance.CORE.getPublicId().toString(),
                     contextId,
                     0,
-                    "",
-                    new ArrayList<>()));
+                    ""));
         }
 
         // Get all parent connections, append all contexts from the parent to the list and return.
@@ -61,15 +65,10 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                 parentContextIds.add(parentContext.contextId());
                                 var contextId =
                                         HashUtil.mediumHash(parentContext.contextId() + parentConnection.getPublicId());
-                                var parents = parentContext.parents();
-                                parents.add(new TaxonomyCrumb(
-                                        parent.getPublicId().toString(),
-                                        parent.getNodeType(),
-                                        parentContext.contextId(),
-                                        parentContext.name(),
-                                        parentContext.path()));
                                 return new TaxonomyContext(
+                                        node.getPublicId().toString(),
                                         LanguageField.fromNode(node),
+                                        node.getNodeType(),
                                         parentContext.rootId(),
                                         parentContext.rootName(),
                                         parentContext.path() + node.getPathPart(),
@@ -89,8 +88,7 @@ public class ContextUpdaterServiceImpl implements ContextUpdaterService {
                                                         .toString()),
                                         contextId,
                                         parentConnection.getRank(),
-                                        parentConnection.getPublicId().toString(),
-                                        parents);
+                                        parentConnection.getPublicId().toString());
                             })
                             .forEach(returnedContexts::add);
                 }));

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -411,21 +411,30 @@ public class NodeService implements SearchService<NodeDTO, Node, NodeRepository>
                                 .map(SearchableTaxonomyResourceType::new)
                                 .toList();
                         var breadcrumbs = context.breadcrumbs();
-                        var parents = context.parents().stream()
-                                .map(parent -> {
-                                    var url = PrettyUrlUtil.createPrettyUrl(
-                                            Optional.ofNullable(context.rootName()),
-                                            parent.name(),
-                                            language,
-                                            parent.contextId(),
-                                            parent.nodeType(),
-                                            newUrlSeparator);
-                                    return new TaxonomyCrumbDTO(
-                                            URI.create(parent.id()),
-                                            parent.contextId(),
-                                            LanguageFieldDTO.fromLanguageField(parent.name()),
-                                            parent.path(),
-                                            url.orElse(parent.path()));
+                        var parentContexts = node.getAllParentContexts();
+                        var parents = context.parentContextIds().stream()
+                                .map(parentCtxId -> {
+                                    var parent = parentContexts.stream()
+                                            .filter(c -> c.contextId().equals(parentCtxId))
+                                            .findFirst();
+                                    if (parent.isPresent()) {
+                                        var p = parent.get();
+                                        var url = PrettyUrlUtil.createPrettyUrl(
+                                                Optional.ofNullable(context.rootName()),
+                                                p.name(),
+                                                language,
+                                                parentCtxId,
+                                                p.nodeType(),
+                                                newUrlSeparator);
+                                        return new TaxonomyCrumbDTO(
+                                                URI.create(p.publicId()),
+                                                parentCtxId,
+                                                LanguageFieldDTO.fromLanguageField(p.name()),
+                                                p.path(),
+                                                url.orElse(p.path()));
+                                    } else {
+                                        return null;
+                                    }
                                 })
                                 .toList();
                         return new TaxonomyContextDTO(

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -181,21 +181,30 @@ public class NodeDTO {
 
     private TaxonomyContextDTO getTaxonomyContextDTO(
             Node entity, boolean newUrlSeparator, TaxonomyContext ctx, LanguageField<String> finalRelevanceName) {
-        var parents = ctx.parents().stream()
-                .map(parent -> {
-                    var url = PrettyUrlUtil.createPrettyUrl(
-                            Optional.ofNullable(ctx.rootName()),
-                            parent.name(),
-                            this.language,
-                            parent.contextId(),
-                            parent.nodeType(),
-                            newUrlSeparator);
-                    return new TaxonomyCrumbDTO(
-                            URI.create(parent.id()),
-                            parent.contextId(),
-                            LanguageFieldDTO.fromLanguageField(parent.name()),
-                            parent.path(),
-                            url.orElse(parent.path()));
+        var parentContexts = entity.getAllParentContexts();
+        var parents = ctx.parentContextIds().stream()
+                .map(parentCtxId -> {
+                    var parent = parentContexts.stream()
+                            .filter(c -> c.contextId().equals(parentCtxId))
+                            .findFirst();
+                    if (parent.isPresent()) {
+                        var p = parent.get();
+                        var url = PrettyUrlUtil.createPrettyUrl(
+                                Optional.ofNullable(ctx.rootName()),
+                                p.name(),
+                                this.language,
+                                parentCtxId,
+                                p.nodeType(),
+                                newUrlSeparator);
+                        return new TaxonomyCrumbDTO(
+                                URI.create(p.publicId()),
+                                parentCtxId,
+                                LanguageFieldDTO.fromLanguageField(p.name()),
+                                p.path(),
+                                url.orElse(p.path()));
+                    } else {
+                        return null;
+                    }
                 })
                 .toList();
         return new TaxonomyContextDTO(

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1571,4 +1571,16 @@
             WHERE contexts != '[]'
         </sql>
     </changeSet>
+
+    <changeSet id="20240923 Add values from node, and drop parents" author="Gunnar Velle">
+        <sql>
+            UPDATE node n
+            SET contexts = (
+            SELECT jsonb_agg(jsonb_set(jsonb_set(obj, '{publicId}', to_jsonb(n.public_id), true), '{nodeType}', to_jsonb(n.node_type), true) - 'parents')
+            FROM jsonb_array_elements(contexts) AS obj
+            )
+            WHERE contexts != '[]'
+        </sql>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
@@ -339,7 +339,9 @@ public class NodeTest extends AbstractIntegrationTest {
         parent2 = parent2.name("parent2");
         node = node.name("name");
         var context1 = new TaxonomyContext(
+                node.getPublicId().toString(),
                 LanguageField.fromNode(node),
+                node.getNodeType(),
                 node.getPublicId().toString(),
                 LanguageField.fromNode(node),
                 node.getPathPart(),
@@ -353,10 +355,11 @@ public class NodeTest extends AbstractIntegrationTest {
                 "urn:relevance:core",
                 "1",
                 0,
-                "urn:connection1",
-                List.of());
+                "urn:connection1");
         var context2 = new TaxonomyContext(
+                node.getPublicId().toString(),
                 LanguageField.fromNode(node),
+                node.getNodeType(),
                 root.getPublicId().toString(),
                 LanguageField.fromNode(root),
                 root.getPathPart() + parent1.getPathPart() + context1.path(),
@@ -372,10 +375,11 @@ public class NodeTest extends AbstractIntegrationTest {
                 "urn:relevance:core",
                 "2",
                 0,
-                "urn:connection2",
-                List.of());
+                "urn:connection2");
         var context3 = new TaxonomyContext(
+                node.getPublicId().toString(),
                 LanguageField.fromNode(node),
+                node.getNodeType(),
                 root.getPublicId().toString(),
                 LanguageField.fromNode(root),
                 root.getPathPart() + parent2.getPathPart() + context1.path(),
@@ -391,8 +395,7 @@ public class NodeTest extends AbstractIntegrationTest {
                 "urn:relevance:core",
                 "3",
                 0,
-                "urn:connection3",
-                List.of());
+                "urn:connection3");
 
         node.setContexts(Set.of(context3, context2, context1));
 


### PR DESCRIPTION
Bruker fremdeles tid på å generer kontekster, men med mindre minnebruk. 
Slutter å lagre parents ferdiggenerert fordi vi uansett har parents i minne via hibernate og kan finne dei på direkten. 