### PR TITLE
Makes sure a context is always selected

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -280,10 +280,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
     }
 
     public Optional<String> getPrimaryPath() {
-        return getContexts().stream()
-                .filter(TaxonomyContext::isPrimary)
-                .map(TaxonomyContext::path)
-                .findFirst();
+        return pickContext(Optional.empty(), Optional.empty(), Optional.empty()).map(TaxonomyContext::path);
     }
 
     /**

--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -280,21 +280,23 @@ public class Node extends DomainObject implements EntityWithMetadata {
     }
 
     public Optional<String> getPrimaryPath() {
-        return pickContext(Optional.empty(), Optional.empty(), Optional.empty()).map(TaxonomyContext::path);
+        return pickContext(Optional.empty(), Optional.empty(), Optional.empty(), Set.of())
+                .map(TaxonomyContext::path);
     }
 
     /**
      * Picks a context based on parameters. If no parameters or no matches, pick by comparing path and primary
      *
-     * @param contextId If this is present, return the context with corresponding id
-     * @param parent    If this is present, filter contexts where parent is in parentIds
-     * @param root      If this is present, return context with this publicId as root. Else pick context containing roots
-     *                  publicId.
+     * @param contextId  If this is present, return the context with corresponding id
+     * @param parent     If this is present, filter contexts where parent is in parentIds
+     * @param root       If this is present, return context with this publicId as root. Else pick context containing roots
+     *                   publicId.
+     * @param contextSet Possibly filtered set of contexts to choose from
      * @return Context
      */
     public Optional<TaxonomyContext> pickContext(
-            Optional<String> contextId, Optional<Node> parent, Optional<Node> root) {
-        var contexts = getContexts();
+            Optional<String> contextId, Optional<Node> parent, Optional<Node> root, Set<TaxonomyContext> contextSet) {
+        var contexts = !contextSet.isEmpty() ? contextSet : getContexts();
         var maybeContext = contextId.flatMap(
                 id -> contexts.stream().filter(c -> c.contextId().equals(id)).findFirst());
         if (maybeContext.isPresent()) {

--- a/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
+++ b/src/test/java/no/ndla/taxonomy/domain/NodeTest.java
@@ -403,38 +403,44 @@ public class NodeTest extends AbstractIntegrationTest {
         node.setContexts(Set.of(context3, context2, context1));
 
         {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.of("1"), Optional.empty(), Optional.empty());
-            assertEquals(context1.contextId(), context.get().contextId());
-        }
-        {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.of("2"), Optional.empty(), Optional.empty());
-            assertEquals(context2.contextId(), context.get().contextId());
-        }
-        {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.of("3"), Optional.empty(), Optional.empty());
-            assertEquals(context3.contextId(), context.get().contextId());
-        }
-        {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.empty(), Optional.empty(), Optional.empty());
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.of("1"), Optional.empty(), Optional.empty(), Set.of());
             assertEquals(context1.contextId(), context.get().contextId());
         }
         {
             Optional<TaxonomyContext> context =
-                    node.pickContext(Optional.empty(), Optional.of(parent1), Optional.of(root));
+                    node.pickContext(Optional.of("2"), Optional.empty(), Optional.empty(), Set.of());
             assertEquals(context2.contextId(), context.get().contextId());
         }
         {
             Optional<TaxonomyContext> context =
-                    node.pickContext(Optional.empty(), Optional.of(parent2), Optional.of(root));
+                    node.pickContext(Optional.of("3"), Optional.empty(), Optional.empty(), Set.of());
             assertEquals(context3.contextId(), context.get().contextId());
         }
         {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.empty(), Optional.empty(), Optional.of(root));
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.empty(), Optional.empty(), Optional.empty(), Set.of());
+            assertEquals(context1.contextId(), context.get().contextId());
+        }
+        {
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.empty(), Optional.of(parent1), Optional.of(root), Set.of());
+            assertEquals(context2.contextId(), context.get().contextId());
+        }
+        {
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.empty(), Optional.of(parent2), Optional.of(root), Set.of());
+            assertEquals(context3.contextId(), context.get().contextId());
+        }
+        {
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.empty(), Optional.empty(), Optional.of(root), Set.of());
             // could be either 2 or 3, either way root is root
             assertEquals(root.getPublicId().toString(), context.get().rootId());
         }
         {
-            Optional<TaxonomyContext> context = node.pickContext(Optional.empty(), Optional.empty(), Optional.empty());
+            Optional<TaxonomyContext> context =
+                    node.pickContext(Optional.empty(), Optional.empty(), Optional.empty(), Set.of());
             assertEquals(context1.contextId(), context.get().contextId()); // Since context1 is shortest
         }
     }


### PR DESCRIPTION
Med filtrering av kontekster kan det oppstå at vi faller tilbake til første primærkobling, men dette passer på at det alltid velges en kontekst og dermed settes path og url fra denne konteksten.