### PR TITLE
Add `rootId` and `parentId` params to search endpoint

### DIFF
--- a/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Resources.java
@@ -21,10 +21,7 @@ import no.ndla.taxonomy.domain.NodeType;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.repositories.ResourceResourceTypeRepository;
 import no.ndla.taxonomy.rest.v1.commands.ResourcePostPut;
-import no.ndla.taxonomy.service.ContextUpdaterService;
-import no.ndla.taxonomy.service.MetadataFilters;
-import no.ndla.taxonomy.service.NodeService;
-import no.ndla.taxonomy.service.QualityEvaluationService;
+import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.NodeDTO;
 import no.ndla.taxonomy.service.dtos.NodeWithParents;
 import no.ndla.taxonomy.service.dtos.ResourceTypeWithConnectionDTO;
@@ -43,6 +40,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
     private final ResourceResourceTypeRepository resourceResourceTypeRepository;
     private final NodeService nodeService;
     private final NodeRepository nodeRepository;
+    private final SearchService searchService;
 
     @Value(value = "${new.url.separator:false}")
     private boolean newUrlSeparator;
@@ -52,13 +50,15 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             ResourceResourceTypeRepository resourceResourceTypeRepository,
             ContextUpdaterService contextUpdaterService,
             NodeService nodeService,
-            QualityEvaluationService qualityEvaluationService) {
+            QualityEvaluationService qualityEvaluationService,
+            SearchService searchService) {
         super(nodeRepository, contextUpdaterService, nodeService, qualityEvaluationService);
 
         this.resourceResourceTypeRepository = resourceResourceTypeRepository;
         this.repository = nodeRepository;
         this.nodeRepository = nodeRepository;
         this.nodeService = nodeService;
+        this.searchService = searchService;
     }
 
     @Override
@@ -117,7 +117,7 @@ public class Resources extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ContentURIs to fetch for query")
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris) {
-        return nodeService.searchByNodeType(
+        return searchService.searchByNodeType(
                 query,
                 ids,
                 contentUris,
@@ -127,6 +127,8 @@ public class Resources extends CrudControllerWithMetadata<Node> {
                 pageSize,
                 page,
                 Optional.of(List.of(NodeType.RESOURCE)),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Subjects.java
@@ -43,6 +43,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
     private final NodeService nodeService;
     private final NodeRepository nodeRepository;
     private final NodeConnectionRepository nodeConnectionRepository;
+    private final SearchService searchService;
 
     @Value(value = "${new.url.separator:false}")
     private boolean newUrlSeparator;
@@ -54,7 +55,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
             NodeService nodeService,
             NodeRepository nodeRepository,
             NodeConnectionRepository nodeConnectionRepository,
-            QualityEvaluationService qualityEvaluationService) {
+            QualityEvaluationService qualityEvaluationService,
+            SearchService searchService) {
         super(nodeRepository, contextUpdaterService, nodeService, qualityEvaluationService);
 
         this.topicTreeSorter = treeSorter;
@@ -62,6 +64,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
         this.nodeService = nodeService;
         this.nodeRepository = nodeRepository;
         this.nodeConnectionRepository = nodeConnectionRepository;
+        this.searchService = searchService;
     }
 
     @Deprecated
@@ -114,7 +117,7 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris) {
 
-        return nodeService.searchByNodeType(
+        return searchService.searchByNodeType(
                 query,
                 ids,
                 contentUris,
@@ -124,6 +127,8 @@ public class Subjects extends CrudControllerWithMetadata<Node> {
                 pageSize,
                 page,
                 Optional.of(List.of(NodeType.SUBJECT)),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Topics.java
@@ -19,10 +19,7 @@ import no.ndla.taxonomy.domain.Node;
 import no.ndla.taxonomy.domain.NodeType;
 import no.ndla.taxonomy.repositories.NodeRepository;
 import no.ndla.taxonomy.rest.v1.commands.TopicPostPut;
-import no.ndla.taxonomy.service.ContextUpdaterService;
-import no.ndla.taxonomy.service.MetadataFilters;
-import no.ndla.taxonomy.service.NodeService;
-import no.ndla.taxonomy.service.QualityEvaluationService;
+import no.ndla.taxonomy.service.*;
 import no.ndla.taxonomy.service.dtos.*;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -37,6 +34,7 @@ import org.springframework.web.bind.annotation.*;
 public class Topics extends CrudControllerWithMetadata<Node> {
     private final NodeRepository nodeRepository;
     private final NodeService nodeService;
+    private final SearchService searchService;
 
     @Value(value = "${new.url.separator:false}")
     private boolean newUrlSeparator;
@@ -45,11 +43,13 @@ public class Topics extends CrudControllerWithMetadata<Node> {
             NodeRepository nodeRepository,
             NodeService nodeService,
             ContextUpdaterService contextUpdaterService,
-            QualityEvaluationService qualityEvaluationService) {
+            QualityEvaluationService qualityEvaluationService,
+            SearchService searchService) {
         super(nodeRepository, contextUpdaterService, nodeService, qualityEvaluationService);
 
         this.nodeRepository = nodeRepository;
         this.nodeService = nodeService;
+        this.searchService = searchService;
     }
 
     @Deprecated
@@ -104,7 +104,7 @@ public class Topics extends CrudControllerWithMetadata<Node> {
             @Parameter(description = "ContentURIs to fetch for query")
                     @RequestParam(value = "contentUris", required = false)
                     Optional<List<String>> contentUris) {
-        return nodeService.searchByNodeType(
+        return searchService.searchByNodeType(
                 query,
                 ids,
                 contentUris,
@@ -114,6 +114,8 @@ public class Topics extends CrudControllerWithMetadata<Node> {
                 pageSize,
                 page,
                 Optional.of(List.of(NodeType.TOPIC)),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodeSearchBody.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodeSearchBody.java
@@ -9,6 +9,7 @@ package no.ndla.taxonomy.rest.v1.commands;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -57,6 +58,14 @@ public class NodeSearchBody {
     @Schema(description = "Filter out programme contexts")
     @JsonProperty
     public boolean filterProgrammes;
+
+    @Schema(description = "Id to root id in context.")
+    @JsonProperty
+    public Optional<URI> rootId = Optional.empty();
+
+    @Schema(description = "Id to parent id in context.")
+    @JsonProperty
+    public Optional<URI> parentId = Optional.empty();
 
     public Optional<Map<String, String>> getCustomFields() {
         return customFields;

--- a/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/NodeServiceTest.java
@@ -45,6 +45,9 @@ public class NodeServiceTest extends AbstractIntegrationTest {
     @Autowired
     private NodeService nodeService;
 
+    @Autowired
+    private SearchService searchService;
+
     @BeforeEach
     void clearAllRepos() {
         nodeRepository.deleteAllAndFlush();
@@ -110,7 +113,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         builder.node(n -> n.nodeType(NodeType.TOPIC));
         var subject = builder.node(n -> n.nodeType(NodeType.SUBJECT));
 
-        var subjects = nodeService.searchByNodeType(
+        var subjects = searchService.searchByNodeType(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -120,9 +123,11 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 10,
                 1,
                 Optional.of(List.of(NodeType.SUBJECT)),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
-        var topics = nodeService.searchByNodeType(
+        var topics = searchService.searchByNodeType(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -132,8 +137,10 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 10,
                 1,
                 Optional.of(List.of(NodeType.TOPIC)),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
-        var all = nodeService.searchByNodeType(
+        var all = searchService.searchByNodeType(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -142,6 +149,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -159,7 +168,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         builder.node(n -> n.nodeType(NodeType.TOPIC).name("Hund"));
         var tiger = builder.node(n -> n.nodeType(NodeType.TOPIC).name("Tiger"));
 
-        var result = nodeService.search(
+        var result = searchService.search(
                 Optional.of("tiger"),
                 Optional.empty(),
                 Optional.empty(),
@@ -168,6 +177,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -186,7 +197,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         idList.add("urn:topic:1");
         idList.add("urn:topic:2");
 
-        var result = nodeService.search(
+        var result = searchService.search(
                 Optional.empty(),
                 Optional.of(idList),
                 Optional.empty(),
@@ -196,13 +207,15 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 10,
                 1,
                 Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         assertEquals(result.getResults().get(0).getId(), new URI("urn:topic:1"));
         assertEquals(result.getResults().get(1).getId(), new URI("urn:topic:2"));
         assertEquals(result.getTotalCount(), 2);
 
-        var result2 = nodeService.search(
+        var result2 = searchService.search(
                 Optional.of("Ape"),
                 Optional.of(idList),
                 Optional.empty(),
@@ -211,6 +224,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 
@@ -234,7 +249,7 @@ public class NodeServiceTest extends AbstractIntegrationTest {
         var idList = new ArrayList<String>();
         idList.add("urn:article:1");
 
-        var result = nodeService.search(
+        var result = searchService.search(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(idList),
@@ -243,6 +258,8 @@ public class NodeServiceTest extends AbstractIntegrationTest {
                 false,
                 10,
                 1,
+                Optional.empty(),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty());
 


### PR DESCRIPTION
Gjør også `SearchService` om til en klasse fremfor et interface som `NodeService` implementerer også.
Gjør koden litt enklere å lese (imo) siden vi ikke lenger trenger generics.

Kan potensielt brukes til å redusere antall kall til taksonomi i graphql i fremtiden :nerd_face: 