### PR TITLE
Resolves to a context even if path is wrong

### DIFF
--- a/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
@@ -162,7 +162,7 @@ public class UrlResolverServiceImpl implements UrlResolverService {
                     .findFirst();
 
             final var resolvedUrl = new ResolvedUrl();
-            // Pick eiter the context matching path or the primary context
+            // Pick either the context matching path or the primary context
             context.or(() -> leafNode.pickContext(Optional.empty(), Optional.empty(), Optional.empty(), Set.of()))
                     .map(Optional::of)
                     .orElseThrow(() -> new NotFoundServiceException("No context found for path"))

--- a/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
+++ b/src/main/java/no/ndla/taxonomy/service/UrlResolverServiceImpl.java
@@ -157,27 +157,33 @@ public class UrlResolverServiceImpl implements UrlResolverService {
             final var normalizedPath =
                     resolvedPathComponents.stream().map(Node::getPathPart).collect(Collectors.joining());
             final var leafNode = resolvedPathComponents.getLast();
-            TaxonomyContext context = leafNode.getContexts().stream()
+            Optional<TaxonomyContext> context = leafNode.getContexts().stream()
                     .filter(ctx -> ctx.path().equals(normalizedPath))
-                    .findFirst()
-                    .orElseThrow(
-                            () -> new NotFoundServiceException("Element with path " + path + " could not be found"));
+                    .findFirst();
 
             final var resolvedUrl = new ResolvedUrl();
-            resolvedUrl.setContentUri(leafNode.getContentUri());
-            resolvedUrl.setId(URI.create(context.publicId()));
-            resolvedUrl.setParents(
-                    context.parentIds().stream().map(URI::create).toList().reversed());
-            resolvedUrl.setName(context.name().fromLanguage(language));
-            resolvedUrl.setPath(context.path());
-            resolvedUrl.setUrl(PrettyUrlUtil.createPrettyUrl(
-                            Optional.ofNullable(context.rootName()),
-                            context.name(),
-                            language,
-                            context.contextId(),
-                            context.nodeType())
-                    .orElse(context.path()));
-
+            // Pick eiter the context matching path or the primary context
+            context.or(() -> leafNode.pickContext(Optional.empty(), Optional.empty(), Optional.empty(), Set.of()))
+                    .map(Optional::of)
+                    .orElseThrow(() -> new NotFoundServiceException("No context found for path"))
+                    .ifPresent(ctx -> {
+                        resolvedUrl.setExactMatch(context.isPresent());
+                        resolvedUrl.setContentUri(leafNode.getContentUri());
+                        resolvedUrl.setId(URI.create(ctx.publicId()));
+                        resolvedUrl.setParents(ctx.parentIds().stream()
+                                .map(URI::create)
+                                .toList()
+                                .reversed());
+                        resolvedUrl.setName(ctx.name().fromLanguage(language));
+                        resolvedUrl.setPath(ctx.path());
+                        resolvedUrl.setUrl(PrettyUrlUtil.createPrettyUrl(
+                                        Optional.ofNullable(ctx.rootName()),
+                                        ctx.name(),
+                                        language,
+                                        ctx.contextId(),
+                                        ctx.nodeType())
+                                .orElse(ctx.path()));
+                    });
             return Optional.of(resolvedUrl);
         } catch (NotFoundServiceException e) {
             return Optional.empty();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/ResolvedUrl.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/ResolvedUrl.java
@@ -46,6 +46,10 @@ public class ResolvedUrl {
     @Schema(description = "Pretty url resource", example = "'/r/subject-name/resource-name/hash'")
     private String url;
 
+    @JsonProperty
+    @Schema(description = "Is this an exact match for the provided path? False if this is another path to the same resource.")
+    private boolean exactMatch;
+
     public URI getId() {
         return id;
     }
@@ -92,5 +96,13 @@ public class ResolvedUrl {
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public boolean isExactMatch() {
+        return exactMatch;
+    }
+
+    public void setExactMatch(boolean exactMatch) {
+        this.exactMatch = exactMatch;
     }
 }

--- a/src/test/java/no/ndla/taxonomy/service/UrlResolverServiceImplTest.java
+++ b/src/test/java/no/ndla/taxonomy/service/UrlResolverServiceImplTest.java
@@ -300,6 +300,8 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
                     t.resource("resource");
                 }));
 
+        builder.node(NodeType.RESOURCE, r -> r.publicId("urn:resource:2").name("Resource Name"));
+
         // Four paths exists to the same resource:
         // /subject:1/topic:1/resource:1
         // /subject:2/topic:2/resource:2
@@ -387,12 +389,18 @@ public class UrlResolverServiceImplTest extends AbstractIntegrationTest {
             assertTrue(resolvedUrl.getUrl().startsWith("/f/biology/"));
         }
 
-        // Test with a non-valid path
-        assertFalse(urlResolverService.resolveUrl("/subject:2/resource:1", "nb").isPresent());
+        // Test with a non-valid path to valid resource
+        {
+            var resolvedUrl = urlResolverService.resolveUrl("/subject:2/resource:1", "nb");
+            assertTrue(resolvedUrl.isPresent());
+            assertFalse(resolvedUrl.get().isExactMatch());
+        }
 
-        // Test with a non-context
-        assertFalse(urlResolverService.resolveUrl("/topic:1/resource:1", "nb").isPresent());
-        assertFalse(urlResolverService.resolveUrl("/topic:2/resource:1", "nb").isPresent());
+        // Test with non-context node
+        {
+            assertFalse(urlResolverService.resolveUrl("/topic:1/resource:2", "nb").isPresent());
+            assertFalse(urlResolverService.resolveUrl("/topic:2/resource:2", "nb").isPresent());
+        }
 
         // Since topic3 is a context in itself, it would be valid to use it as root
         {


### PR DESCRIPTION
Før returnerte vi 404 på pather som ikkje finnes, sjølv om ressursen finnes i en kontekst. Dette vil gi en kontekst så lenge noden er aktiv og i en kontekst. Legger til boolean felt exactMatch som kan brukes av klienter.