### PR TITLE
Only fetch parents if node is fetched as standalone and not as child

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -508,7 +508,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
         return all;
     }
 
-    public Collection<TaxonomyContext> getAllParentContexts() {
+    public Set<TaxonomyContext> getAllParentContexts() {
         return getAllParentsRecursive().stream()
                 .map(Node::getContexts)
                 .flatMap(Collection::stream)

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -237,7 +237,8 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                         Optional.empty(),
                         includeContexts,
                         filterProgrammes,
-                        isVisible))
+                        isVisible,
+                        false))
                 .collect(Collectors.toList());
         return new SearchResultDTO<>(ids.getTotalElements(), page.get(), pageSize.get(), contents);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/Nodes.java
@@ -130,6 +130,7 @@ public class Nodes extends CrudControllerWithMetadata<Node> {
                 metadataFilters,
                 includeContexts,
                 filterProgrammes,
+                true,
                 rootId,
                 parentId);
     }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/dtos/searchapi/TaxonomyContextDTO.java
@@ -36,6 +36,6 @@ public record TaxonomyContextDTO(
         @JsonProperty @Schema(description = "The rank of the parent connection object") int rank,
         @JsonProperty @Schema(description = "The id of the parent connection object") String connectionId,
         @JsonProperty @Schema(description = "Pretty-url of this particular context") String url,
-        @JsonProperty @Schema(description = "List of all parents to this context") List<TaxonomyCrumbDTO> parents) {
+        @JsonProperty @Schema(description = "List of all parents to this context. Empty if node is fetched as child") List<TaxonomyCrumbDTO> parents) {
 // spotless:on
 }

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -121,7 +121,8 @@ public class NodeService {
                                     contextId,
                                     includeContexts,
                                     filterProgrammes,
-                                    metadataFilters.getVisible().orElse(false)))
+                                    metadataFilters.getVisible().orElse(false),
+                                    false))
                             .toList();
                     listToReturn.addAll(dtos);
                 });
@@ -174,7 +175,8 @@ public class NodeService {
                 Optional.empty(),
                 includeContexts,
                 filterProgrammes,
-                isVisible);
+                isVisible,
+                true);
     }
 
     public Optional<Node> getMaybeNode(URI publicId) {

--- a/src/main/java/no/ndla/taxonomy/service/NodeService.java
+++ b/src/main/java/no/ndla/taxonomy/service/NodeService.java
@@ -87,6 +87,7 @@ public class NodeService {
             MetadataFilters metadataFilters,
             Optional<Boolean> includeContexts,
             boolean filterProgrammes,
+            boolean includeParents,
             Optional<URI> rootId,
             Optional<URI> parentId) {
         final List<NodeDTO> listToReturn = new ArrayList<>();
@@ -122,7 +123,7 @@ public class NodeService {
                                     includeContexts,
                                     filterProgrammes,
                                     metadataFilters.getVisible().orElse(false),
-                                    false))
+                                    includeParents))
                             .toList();
                     listToReturn.addAll(dtos);
                 });

--- a/src/main/java/no/ndla/taxonomy/service/SearchService.java
+++ b/src/main/java/no/ndla/taxonomy/service/SearchService.java
@@ -143,6 +143,7 @@ public class SearchService {
                         Optional.empty(),
                         includeContexts,
                         filterProgrammes,
+                        false,
                         false))
                 .collect(Collectors.toList());
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeChildDTO.java
@@ -56,7 +56,8 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 Optional.empty(),
                 includeContexts,
                 filterProgrammes,
-                isVisible);
+                isVisible,
+                false);
 
         // This must be enabled when ed is updated to update metadata for connections.
         // this.metadata = new MetadataDto(nodeConnection.getMetadata());
@@ -84,7 +85,8 @@ public class NodeChildDTO extends NodeDTO implements TreeSorter.Sortable {
                 Optional.empty(),
                 Optional.of(false),
                 false,
-                true);
+                true,
+                false);
 
         this.rank = nodeConnection.getRank();
         this.connectionId = nodeConnection.getPublicId();

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeDTO.java
@@ -108,10 +108,10 @@ public class NodeDTO {
             Optional<String> contextId,
             Optional<Boolean> includeContexts,
             boolean filterProgrammes,
-            boolean isVisible) {
+            boolean isVisible,
+            boolean includeParents) {
 
         var contexts = entity.getContexts();
-        var parentContexts = entity.getAllParentContexts();
         var visibleContexts =
                 isVisible ? contexts.stream().filter(TaxonomyContext::isVisible).collect(Collectors.toSet()) : contexts;
         var filteredContexts = visibleContexts.stream()
@@ -151,6 +151,7 @@ public class NodeDTO {
         this.nodeType = entity.getNodeType();
         this.contextids = entity.getContextIds();
 
+        Set<TaxonomyContext> parentContexts = includeParents ? entity.getAllParentContexts() : Set.of();
         Optional<TaxonomyContext> selected = entity.pickContext(contextId, parent, root, filteredContexts);
         selected.ifPresent(ctx -> {
             var contextDto = getTaxonomyContextDTO(entity, ctx, parentContexts);
@@ -201,6 +202,7 @@ public class NodeDTO {
                         return null;
                     }
                 })
+                .filter(Objects::nonNull)
                 .toList();
         var relevance = Relevance.unsafeGetRelevance(URI.create(ctx.relevanceId()));
         return new TaxonomyContextDTO(

--- a/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/NodeWithParents.java
@@ -29,7 +29,16 @@ public class NodeWithParents extends NodeDTO {
     public NodeWithParents() {}
 
     public NodeWithParents(Node node, String languageCode, Optional<Boolean> includeContexts) {
-        super(Optional.empty(), Optional.empty(), node, languageCode, Optional.empty(), includeContexts, false, true);
+        super(
+                Optional.empty(),
+                Optional.empty(),
+                node,
+                languageCode,
+                Optional.empty(),
+                includeContexts,
+                false,
+                true,
+                false);
 
         node.getParentConnections().stream()
                 .map(nodeResource -> {


### PR DESCRIPTION
Var visst en dyr operasjon å hente alle parents rekursivt. Endrer slik at det kun hentes når du henter en node direkte.