### PR TITLE
Fix bug with calculating quality evaluation

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/GradeAverage.java
+++ b/src/main/java/no/ndla/taxonomy/domain/GradeAverage.java
@@ -11,23 +11,23 @@ import java.util.Collection;
 import java.util.Optional;
 
 public class GradeAverage {
-    public GradeAverage(double averageValue, int count) {
-        this.averageValue = averageValue;
+    public GradeAverage(int averageSum, int count) {
+        this.averageSum = averageSum;
         this.count = count;
     }
 
-    double averageValue;
+    int averageSum;
     int count;
 
     public static GradeAverage fromGrades(Collection<Optional<Grade>> grades) {
         var existing = grades.stream().flatMap(Optional::stream).toList();
         var count = existing.size();
-        var avg = existing.stream().mapToInt(Grade::toInt).average().orElse(0.0);
-        return new GradeAverage(avg, count);
+        var sum = existing.stream().mapToInt(Grade::toInt).sum();
+        return new GradeAverage(sum, count);
     }
 
-    public double getAverageValue() {
-        return averageValue;
+    public int getAverageSum() {
+        return averageSum;
     }
 
     public int getCount() {
@@ -44,11 +44,15 @@ public class GradeAverage {
         }
 
         GradeAverage that = (GradeAverage) obj;
-        return Double.compare(that.averageValue, averageValue) == 0 && count == that.count;
+        return averageSum == that.averageSum && count == that.count;
     }
 
     @Override
     public String toString() {
-        return "GradeAverage{averageValue=" + averageValue + ", count=" + count + '}';
+        return "GradeAverage{averageSum=" + averageSum + ", count=" + count + '}';
+    }
+
+    public double getAverageValue() {
+        return (double) averageSum / count;
     }
 }

--- a/src/main/java/no/ndla/taxonomy/domain/UpdateOrDelete.java
+++ b/src/main/java/no/ndla/taxonomy/domain/UpdateOrDelete.java
@@ -28,6 +28,10 @@ public class UpdateOrDelete<T> {
         return new UpdateOrDelete<>();
     }
 
+    public static <T> UpdateOrDelete<T> Update(T value) {
+        return new UpdateOrDelete<>(value, false);
+    }
+
     public boolean isDelete() {
         return delete;
     }

--- a/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
+++ b/src/main/java/no/ndla/taxonomy/repositories/NodeRepository.java
@@ -51,7 +51,7 @@ public interface NodeRepository extends TaxonomyRepository<Node> {
     @Query(
             """
             UPDATE Node n
-            SET n.childQualityEvaluationAverage = NULL,
+            SET n.childQualityEvaluationSum = 0,
                 n.childQualityEvaluationCount = 0
             """)
     void wipeQualityEvaluationAverages();

--- a/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/CrudController.java
@@ -76,7 +76,7 @@ public abstract class CrudController<T extends DomainEntity> {
 
         if (parents.isPresent()) {
             var p = parents.get();
-            qualityEvaluationService.updateQualityEvaluationOf(p, oldGrade, Optional.empty());
+            qualityEvaluationService.updateQualityEvaluationOfRecursive(p, oldGrade, Optional.empty());
         }
     }
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/GradeAverageDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/GradeAverageDTO.java
@@ -29,7 +29,8 @@ public class GradeAverageDTO {
 
     public static Optional<GradeAverageDTO> fromNode(Node node) {
         return node.getChildQualityEvaluationAverage().map(ga -> {
-            var roundedAvg = roundToSingleDecimal(ga.getAverageValue());
+            var avg = (double) ga.getAverageSum() / ga.getCount();
+            var roundedAvg = roundToSingleDecimal(avg);
             var count1 = ga.getCount();
             return new GradeAverageDTO(roundedAvg, count1);
         });

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -1602,4 +1602,11 @@
         </sql>
     </changeSet>
 
+    <changeSet id="20250120 Quality evaluation sum instead of calculated" author="Jonas Natten">
+        <dropColumn tableName="node" columnName="child_quality_evaluation_average"/>
+        <addColumn tableName="node">
+            <column name="child_quality_evaluation_sum" type="int" defaultValueNumeric="0" />
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
NB: Krever at vi kjører et kall til `/v1/admin/buildAverageTree` for å gjenskape snittene.

Jeg tror denne skal fikse problemet med at kvalitetsvurderingssnittene noen ganger er feil.

Var en bug der som gjorde at databasen ikke var oppdatert ved en rekalkulering som gjorde at "count" var feil.
Dette vil jo propagere dersom noen oppdaterer et snitt som er feil.

Endrer også til at vi lagrer sum'en og heller regner ut snittet på vei ut av apiet. Dette gjør at vi unngår floating point precision problemer.
