### PR TITLE
Check token for audience

### DIFF
--- a/src/main/java/no/ndla/taxonomy/security/AuthFilter.java
+++ b/src/main/java/no/ndla/taxonomy/security/AuthFilter.java
@@ -40,6 +40,9 @@ import org.springframework.web.filter.GenericFilterBean;
 @Order(2)
 public class AuthFilter extends GenericFilterBean {
 
+    @Value(value = "${auth0.audience}")
+    private String audience;
+
     @Value(value = "${auth0.issuer}")
     private String issuer;
 
@@ -79,7 +82,7 @@ public class AuthFilter extends GenericFilterBean {
 
     private DecodedJWT verifyWebToken(String token) {
         Algorithm algorithm = Algorithm.RSA256(publicKey, null);
-        JWTVerifier verifier = JWT.require(algorithm).withIssuer(issuer).build();
+        JWTVerifier verifier = JWT.require(algorithm).withAnyOfAudience(audience).build();
         return verifier.verify(token);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,7 @@ spring:
       on-profile: staging
 
 auth0:
+  audience: ndla_system
   issuer: https://ndla-staging.eu.auth0.com/
   jwks.kid: NDFFOTUxMjQ1ODNDMTlBRkE0RkQ4NDc0RjUxNjUxREE0MTUyQTQ3NQ
 
@@ -73,6 +74,7 @@ spring:
       on-profile: prod
 
 auth0:
+  audience: ndla_system
   issuer: https://ndla.eu.auth0.com/
   jwks.kid: OEI1MUU4ODk5NzM5MzI2MzZDODk1N0YwQzdDMDQyODVCQzQ3QTI0MA
 
@@ -85,6 +87,7 @@ spring:
       on-profile: test
 
 auth0:
+  audience: ndla_system
   issuer: https://ndla-test.eu.auth0.com/
   jwks.kid: QzlEOTQ5M0NGMDk4NjExOEJGMjc2MjVFODhEQkE1NUI2NkE0RTQyRg
 


### PR DESCRIPTION
Gjør at vi kan støtte både auth0-adressa og ndla.no adressa for issuer. Vi bruker fremdeles issuer for å hente ut JkwProvider så antar dette ikkje går på bekostning av noen sikkerhet.