### PR TITLE
fix: make `requiresTechnicalEvaluation` nullable

### DIFF
--- a/src/main/java/no/ndla/taxonomy/domain/Node.java
+++ b/src/main/java/no/ndla/taxonomy/domain/Node.java
@@ -90,7 +90,7 @@ public class Node extends DomainObject implements EntityWithMetadata {
     private int childQualityEvaluationCount;
 
     @Column(name = "requires_technical_evaluation")
-    private boolean requiresTechnicalEvaluation;
+    private Boolean requiresTechnicalEvaluation;
 
     @Column(name = "technical_evaluation_comment")
     private String technicalEvaluationComment;
@@ -282,12 +282,12 @@ public class Node extends DomainObject implements EntityWithMetadata {
         this.qualityEvaluationComment = qualityEvaluationComment.orElse(null);
     }
 
-    public boolean requiresTechnicalEvaluation() {
-        return requiresTechnicalEvaluation;
+    public Optional<Boolean> requiresTechnicalEvaluation() {
+        return Optional.ofNullable(requiresTechnicalEvaluation);
     }
 
-    public void setRequiresTechnicalEvaluation(boolean requiresTechnicalEvaluation) {
-        this.requiresTechnicalEvaluation = requiresTechnicalEvaluation;
+    public void setRequiresTechnicalEvaluation(Optional<Boolean> requiresTechnicalEvaluation) {
+        this.requiresTechnicalEvaluation = requiresTechnicalEvaluation.orElse(null);
     }
 
     public Optional<String> getTechnicalEvaluationComment() {

--- a/src/main/java/no/ndla/taxonomy/domain/TechnicalEvaluationDTODeserializer.java
+++ b/src/main/java/no/ndla/taxonomy/domain/TechnicalEvaluationDTODeserializer.java
@@ -12,15 +12,12 @@ import java.util.Optional;
 import no.ndla.taxonomy.service.dtos.TechnicalEvaluationDTO;
 
 public class TechnicalEvaluationDTODeserializer extends UpdateOrDelete.Deserializer<TechnicalEvaluationDTO> {
-    private Optional<String> getComment(JsonNode node) {
-        return Optional.ofNullable(node.get("comment")).map(JsonNode::textValue);
-    }
-
     @Override
     protected TechnicalEvaluationDTO deserializeInner(JsonNode node) {
-        var requiresEvaluationNode = node.get("requiresEvaluation");
-        var requiresEvaluation = requiresEvaluationNode != null && requiresEvaluationNode.asBoolean();
-        var comment = getComment(node);
+        var requiresEvaluation = Optional.ofNullable(node.get("requiresEvaluation"))
+                .filter(JsonNode::isBoolean)
+                .map(JsonNode::booleanValue);
+        var comment = Optional.ofNullable(node.get("comment")).map(JsonNode::textValue);
         return new TechnicalEvaluationDTO(requiresEvaluation, comment);
     }
 }

--- a/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodePostPut.java
+++ b/src/main/java/no/ndla/taxonomy/rest/v1/commands/NodePostPut.java
@@ -115,12 +115,14 @@ public class NodePostPut implements UpdatableDto<Node> {
         }
 
         if (this.technicalEvaluation.isDelete()) {
-            node.setRequiresTechnicalEvaluation(false);
+            node.setRequiresTechnicalEvaluation(Optional.empty());
             node.setTechnicalEvaluationComment(Optional.empty());
         } else {
             this.technicalEvaluation.getValue().ifPresent(te -> {
-                node.setRequiresTechnicalEvaluation(te.requiresEvaluation());
-                node.setTechnicalEvaluationComment(te.requiresEvaluation() ? te.getComment() : Optional.empty());
+                te.requiresEvaluation().ifPresent(requiresEvaluation -> {
+                    node.setRequiresTechnicalEvaluation(Optional.of(requiresEvaluation));
+                    node.setTechnicalEvaluationComment(requiresEvaluation ? te.getComment() : Optional.empty());
+                });
             });
         }
 

--- a/src/main/java/no/ndla/taxonomy/service/dtos/TechnicalEvaluationDTO.java
+++ b/src/main/java/no/ndla/taxonomy/service/dtos/TechnicalEvaluationDTO.java
@@ -16,19 +16,19 @@ import no.ndla.taxonomy.domain.Node;
 public class TechnicalEvaluationDTO {
     @JsonProperty
     @Schema(description = "Whether this node requires a technical evaluation.")
-    private boolean requiresEvaluation;
+    private Optional<Boolean> requiresEvaluation = Optional.empty();
 
     @JsonProperty
     @Schema(description = "Notes for the technical evaluation of this node.")
     private Optional<String> comment = Optional.empty();
 
-    public TechnicalEvaluationDTO(boolean requiresEvaluation, Optional<String> comment) {
+    public TechnicalEvaluationDTO(Optional<Boolean> requiresEvaluation, Optional<String> comment) {
         this.requiresEvaluation = requiresEvaluation;
         this.comment = comment;
     }
 
     public static Optional<TechnicalEvaluationDTO> fromNode(Node node) {
-        if (!node.requiresTechnicalEvaluation()
+        if (node.requiresTechnicalEvaluation().isEmpty()
                 && node.getTechnicalEvaluationComment().isEmpty()) {
             return Optional.empty();
         }
@@ -36,11 +36,11 @@ public class TechnicalEvaluationDTO {
                 new TechnicalEvaluationDTO(node.requiresTechnicalEvaluation(), node.getTechnicalEvaluationComment()));
     }
 
-    public boolean requiresEvaluation() {
+    public Optional<Boolean> requiresEvaluation() {
         return requiresEvaluation;
     }
 
-    public void setRequiresEvaluation(boolean requiresEvaluation) {
+    public void setRequiresEvaluation(Optional<Boolean> requiresEvaluation) {
         this.requiresEvaluation = requiresEvaluation;
     }
 

--- a/src/main/resources/db-master-changelog.xml
+++ b/src/main/resources/db-master-changelog.xml
@@ -875,9 +875,19 @@
         </addColumn>
     </changeSet>
 
-    <changeSet id="20260401 Make requires_technical_evaluation not nullable" author="you">
+    <changeSet id="20260401 Make requires_technical_evaluation not nullable" author="Amandus Thorsrud">
         <addNotNullConstraint tableName="node" columnName="requires_technical_evaluation" columnDataType="boolean"
                               defaultNullValue="false"/>
+    </changeSet>
+
+    <changeSet id="20260407" author="Amandus Thorsrud">
+        <dropNotNullConstraint
+                tableName="node"
+                columnName="requires_technical_evaluation"
+                columnDataType="boolean"/>
+        <update tableName="node">
+            <column name="requires_technical_evaluation" value="null"/>
+        </update>
     </changeSet>
 
 </databaseChangeLog>

--- a/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
+++ b/src/test/java/no/ndla/taxonomy/rest/v1/NodesTest.java
@@ -1840,12 +1840,12 @@ public class NodesTest extends RestTest {
     }
 
     @Test
-    public void requires_technical_evaluation_defaults_to_false() {
+    public void requires_technical_evaluation_defaults_to_empty() {
         var node = builder.node(NodeType.TOPIC);
         var id = node.getPublicId();
 
         var found = nodeRepository.getByPublicId(id);
-        assertFalse(found.requiresTechnicalEvaluation());
+        assertTrue(found.requiresTechnicalEvaluation().isEmpty());
         assertTrue(found.getTechnicalEvaluationComment().isEmpty());
     }
 
@@ -1854,25 +1854,25 @@ public class NodesTest extends RestTest {
         var command = new NodePostPut() {
             {
                 nodeType = NodeType.TOPIC;
-                technicalEvaluation =
-                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(true, Optional.of("Needs review")));
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.of(true), Optional.of("Needs review")));
             }
         };
         var id = getId(testUtils.createResource("/v1/nodes", command));
 
         var found = nodeRepository.getByPublicId(id);
-        assertTrue(found.requiresTechnicalEvaluation());
+        assertTrue(found.requiresTechnicalEvaluation().orElseThrow());
         assertEquals("Needs review", found.getTechnicalEvaluationComment().orElseThrow());
 
         var command2 = new NodePostPut() {
             {
-                technicalEvaluation =
-                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(false, Optional.of("Needs review")));
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.of(false), Optional.of("Needs review")));
             }
         };
         testUtils.updateResource("/v1/nodes/" + id, command2);
         var found2 = nodeRepository.getByPublicId(id);
-        assertFalse(found2.requiresTechnicalEvaluation());
+        assertFalse(found2.requiresTechnicalEvaluation().orElseThrow());
         assertTrue(found2.getTechnicalEvaluationComment().isEmpty());
     }
 
@@ -1881,25 +1881,26 @@ public class NodesTest extends RestTest {
         var command = new NodePostPut() {
             {
                 nodeType = NodeType.TOPIC;
-                technicalEvaluation = UpdateOrDelete.Update(new TechnicalEvaluationDTO(true, Optional.empty()));
+                technicalEvaluation =
+                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(Optional.of(true), Optional.empty()));
             }
         };
         var id = getId(testUtils.createResource("/v1/nodes", command));
 
         var found = nodeRepository.getByPublicId(id);
-        assertTrue(found.requiresTechnicalEvaluation());
+        assertTrue(found.requiresTechnicalEvaluation().orElseThrow());
         assertTrue(found.getTechnicalEvaluationComment().isEmpty());
 
         var command2 = new NodePostPut() {
             {
-                technicalEvaluation =
-                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(true, Optional.of("Needs review")));
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.of(true), Optional.of("Needs review")));
             }
         };
         testUtils.updateResource("/v1/nodes/" + id, command2);
 
         var found2 = nodeRepository.getByPublicId(id);
-        assertTrue(found2.requiresTechnicalEvaluation());
+        assertTrue(found2.requiresTechnicalEvaluation().orElseThrow());
         assertEquals("Needs review", found2.getTechnicalEvaluationComment().orElseThrow());
     }
 
@@ -1908,14 +1909,14 @@ public class NodesTest extends RestTest {
         var command = new NodePostPut() {
             {
                 nodeType = NodeType.TOPIC;
-                technicalEvaluation =
-                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(false, Optional.of("Needs review")));
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.of(false), Optional.of("Needs review")));
             }
         };
         var id = getId(testUtils.createResource("/v1/nodes", command));
 
         var found = nodeRepository.getByPublicId(id);
-        assertFalse(found.requiresTechnicalEvaluation());
+        assertFalse(found.requiresTechnicalEvaluation().orElseThrow());
         assertTrue(found.getTechnicalEvaluationComment().isEmpty());
     }
 
@@ -1924,8 +1925,8 @@ public class NodesTest extends RestTest {
         var command = new NodePostPut() {
             {
                 nodeType = NodeType.TOPIC;
-                technicalEvaluation =
-                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(true, Optional.of("Needs review")));
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.of(true), Optional.of("Needs review")));
             }
         };
         var id = getId(testUtils.createResource("/v1/nodes", command));
@@ -1934,8 +1935,32 @@ public class NodesTest extends RestTest {
 
         var nodeDTO = testUtils.getObject(NodeDTO.class, response);
         var te = nodeDTO.getTechnicalEvaluation().orElseThrow();
-        assertTrue(te.requiresEvaluation());
+        assertTrue(te.requiresEvaluation().orElseThrow());
         assertEquals("Needs review", te.getComment().orElseThrow());
+    }
+
+    @Test
+    public void that_setting_comment_with_empty_requires_evaluation_does_nothing() throws Exception {
+        var command = new NodePostPut() {
+            {
+                nodeType = NodeType.TOPIC;
+                technicalEvaluation =
+                        UpdateOrDelete.Update(new TechnicalEvaluationDTO(Optional.of(true), Optional.empty()));
+            }
+        };
+        var id = getId(testUtils.createResource("/v1/nodes", command));
+
+        var command2 = new NodePostPut() {
+            {
+                technicalEvaluation = UpdateOrDelete.Update(
+                        new TechnicalEvaluationDTO(Optional.empty(), Optional.of("Needs review")));
+            }
+        };
+        testUtils.updateResource("/v1/nodes/" + id, command2);
+
+        var found = nodeRepository.getByPublicId(id);
+        assertTrue(found.requiresTechnicalEvaluation().orElseThrow());
+        assertTrue(found.getTechnicalEvaluationComment().isEmpty());
     }
 
     public void testQualityEvaluationAverage(Node inputNode, int expectedCount, double expectedAverage) {


### PR DESCRIPTION
Jeg hadde visst tenkt riktig originalt med databasemodellen, men ikke med Java-modellen :sweat_smile:

Endrer `requiresTechnicalEvaluation` til å være nullable (`Boolean`) slik at vi kan representere ressurser som ikke har fått noen vurdering om den trenger teknisk gjennomgang enda. Dette trengs for at frontend skal kunne sette toggle for "teknisk gjennomgang" å være default skrudd på dersom det ikke finnes fra før av.